### PR TITLE
Use go.temporal.io/temporal-proto module

### DIFF
--- a/cmd/samples/common/factory.go
+++ b/cmd/samples/common/factory.go
@@ -3,8 +3,8 @@ package common
 import (
 	"errors"
 
-	"github.com/temporalio/temporal-proto-go/workflowservice"
 	"github.com/uber-go/tally"
+	"go.temporal.io/temporal-proto/workflowservice"
 	"go.temporal.io/temporal/client"
 	"go.temporal.io/temporal/encoded"
 	"go.temporal.io/temporal/workflow"

--- a/cmd/samples/common/sample_helper.go
+++ b/cmd/samples/common/sample_helper.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/uber-go/tally"
+	"go.temporal.io/temporal-proto/workflowservice"
+	"go.temporal.io/temporal/client"
 	"go.temporal.io/temporal/encoded"
 	"go.temporal.io/temporal/worker"
 	"go.temporal.io/temporal/workflow"
 	"go.uber.org/zap"
-
-	"github.com/temporalio/temporal-proto-go/workflowservice"
-	"github.com/uber-go/tally"
-	"go.temporal.io/temporal/client"
 	"gopkg.in/yaml.v2"
 )
 

--- a/cmd/samples/cron/cron_workflow_test.go
+++ b/cmd/samples/cron/cron_workflow_test.go
@@ -5,11 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"go.temporal.io/temporal/activity"
-	"go.temporal.io/temporal/encoded"
-
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"go.temporal.io/temporal/activity"
+	"go.temporal.io/temporal/encoded"
 	"go.temporal.io/temporal/testsuite"
 	"go.temporal.io/temporal/workflow"
 )

--- a/cmd/samples/pso/workflow.go
+++ b/cmd/samples/pso/workflow.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pborman/uuid"
 	"go.temporal.io/temporal"
-
 	"go.temporal.io/temporal/workflow"
 )
 

--- a/cmd/samples/pso/workflow_test.go
+++ b/cmd/samples/pso/workflow_test.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"go.temporal.io/temporal/workflow"
-
 	"github.com/stretchr/testify/require"
-
 	"go.temporal.io/temporal/activity"
 	"go.temporal.io/temporal/encoded"
 	"go.temporal.io/temporal/testsuite"
 	"go.temporal.io/temporal/worker"
+	"go.temporal.io/temporal/workflow"
 )
 
 func Test_Workflow(t *testing.T) {

--- a/cmd/samples/recipes/helloworld/replay_test.go
+++ b/cmd/samples/recipes/helloworld/replay_test.go
@@ -3,13 +3,12 @@ package main
 import (
 	"testing"
 
-	"go.temporal.io/temporal/worker"
-	"go.uber.org/zap"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/temporalio/temporal-proto-go/workflowservicemock"
+	"go.temporal.io/temporal-proto/workflowservicemock"
+	"go.temporal.io/temporal/worker"
+	"go.uber.org/zap"
 )
 
 type replayTestSuite struct {

--- a/cmd/samples/recipes/retryactivity/retry_activity_workflow_test.go
+++ b/cmd/samples/recipes/retryactivity/retry_activity_workflow_test.go
@@ -5,10 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"go.temporal.io/temporal/activity"
-
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"go.temporal.io/temporal/activity"
 	"go.temporal.io/temporal/testsuite"
 )
 

--- a/cmd/samples/recipes/searchattributes/main.go
+++ b/cmd/samples/recipes/searchattributes/main.go
@@ -5,11 +5,10 @@ import (
 	"flag"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/pborman/uuid"
 	"go.temporal.io/temporal/client"
 	"go.temporal.io/temporal/worker"
+	"go.uber.org/zap"
 
 	"github.com/temporalio/temporal-go-samples/cmd/samples/common"
 )

--- a/cmd/samples/recipes/searchattributes/searchattributes_workflow.go
+++ b/cmd/samples/recipes/searchattributes/searchattributes_workflow.go
@@ -8,10 +8,9 @@ import (
 	"strconv"
 	"time"
 
+	"go.temporal.io/temporal-proto/common"
+	"go.temporal.io/temporal-proto/workflowservice"
 	"go.temporal.io/temporal/activity"
-
-	"github.com/temporalio/temporal-proto-go/common"
-	"github.com/temporalio/temporal-proto-go/workflowservice"
 	"go.temporal.io/temporal/client"
 	"go.temporal.io/temporal/workflow"
 	"go.uber.org/zap"

--- a/cmd/samples/recipes/searchattributes/searchattributes_workflow_test.go
+++ b/cmd/samples/recipes/searchattributes/searchattributes_workflow_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"github.com/temporalio/temporal-proto-go/common"
+	"go.temporal.io/temporal-proto/common"
 	"go.temporal.io/temporal/testsuite"
 )
 

--- a/cmd/samples/recovery/recovery_workflow.go
+++ b/cmd/samples/recovery/recovery_workflow.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
-	"github.com/temporalio/temporal-proto-go/common"
-	"github.com/temporalio/temporal-proto-go/enums"
-	"github.com/temporalio/temporal-proto-go/workflowservice"
 	"go.temporal.io/temporal"
+	"go.temporal.io/temporal-proto/common"
+	"go.temporal.io/temporal-proto/enums"
+	"go.temporal.io/temporal-proto/workflowservice"
 	"go.temporal.io/temporal/activity"
 	"go.temporal.io/temporal/client"
 	"go.temporal.io/temporal/workflow"

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
-	github.com/temporalio/temporal-proto-go v0.0.0-20200103184242-06c5b2472e15
 	github.com/uber-go/tally v3.3.13+incompatible
-	go.temporal.io/temporal v0.10.2
+	go.temporal.io/temporal v0.10.3
+	go.temporal.io/temporal-proto v0.0.0-20200104005919-6abdf3300ac7
 	go.uber.org/zap v1.13.0
 	google.golang.org/grpc v1.26.0
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/temporalio/temporal-proto-go v0.0.0-20200103184242-06c5b2472e15 h1:CRdB+axODpCGSPShGUETU3Tcx/GGYnDpxJ0K6UVwYxs=
-github.com/temporalio/temporal-proto-go v0.0.0-20200103184242-06c5b2472e15/go.mod h1:P197dHJeYi4bMf0n/7CAbhK4VlzCfK7KlsyP44biIdI=
 github.com/uber-go/atomic v1.4.0 h1:yOuPqEq4ovnhEjpHmfFwsqBXDYbQeT6Nb0bwD6XnD5o=
 github.com/uber-go/atomic v1.4.0/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
 github.com/uber-go/mapdecode v1.0.0 h1:euUEFM9KnuCa1OBixz1xM+FIXmpixyay5DLymceOVrU=
@@ -143,8 +141,10 @@ github.com/uber/jaeger-lib v1.5.0 h1:OHbgr8l656Ub3Fw5k9SWnBfIEwvoHQ+W2y+Aa9D1Uyo
 github.com/uber/jaeger-lib v1.5.0/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/uber/tchannel-go v1.16.0 h1:B7dirDs15/vJJYDeoHpv3xaEUjuRZ38Rvt1qq9g7pSo=
 github.com/uber/tchannel-go v1.16.0/go.mod h1:Rrgz1eL8kMjW/nEzZos0t+Heq0O4LhnUJVA32OvWKHo=
-go.temporal.io/temporal v0.10.2 h1:AvYEBm0E/IJmMe5F52emfT/cGHKwtXgyDGhpcbmUqOE=
-go.temporal.io/temporal v0.10.2/go.mod h1:/qEvi9RT0p+50DqXa15UiRauNSxfx38HMxev3sfaZFY=
+go.temporal.io/temporal v0.10.3 h1:uuZA/tbv7IIFl9rgR9aMJEiAmSp/pnspR8MWRNjsSkU=
+go.temporal.io/temporal v0.10.3/go.mod h1:dC56oH+e6QhhlGUU0u7eQpLRZ7TWr9Rgv1Z7ZLThbMs=
+go.temporal.io/temporal-proto v0.0.0-20200104005919-6abdf3300ac7 h1:NdZxGjp9KcmERWIW4dbQPSCCWIthkV003/0l/J3fncQ=
+go.temporal.io/temporal-proto v0.0.0-20200104005919-6abdf3300ac7/go.mod h1:Hcd8jaNNn/g6w3+8vHvTz1QIuodcT1skcUYD6gYoA80=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/dig v1.8.0/go.mod h1:X34SnWGr8Fyla9zQNO2GSO2D+TIuqB14OS8JhYocIyw=
 go.uber.org/fx v1.10.0/go.mod h1:vLRicqpG/qQEzno4SYU86iCwfT95EZza+Eba0ItuxqY=


### PR DESCRIPTION
Simple rename from `github.com/temporalio/temporal-proto-go/workflowservice` ro `go.temporal.io/temporal-proto/workflowservice` and sort imports.