### PR TITLE
Fix small string typo in branch workflow

### DIFF
--- a/branch/branch_workflow.go
+++ b/branch/branch_workflow.go
@@ -32,7 +32,7 @@ func SampleBranchWorkflow(ctx workflow.Context, totalBranches int) (result []str
 	for _, future := range futures {
 		var singleResult string
 		err = future.Get(ctx, &singleResult)
-		logger.Info("Activity returned with result", "resutl", singleResult)
+		logger.Info("Activity returned with result", "result", singleResult)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
While this does not affect correctness or functionality it feels like a nice thing to clean up.