### PR TITLE
Add Fixtures folder

### DIFF
--- a/temporal-fixtures/README.md
+++ b/temporal-fixtures/README.md
@@ -1,0 +1,7 @@
+# Temporal Fixtures
+
+Temporal Fixtures are not meant to be educational code samples.
+
+Instead, their purpose is to quickly create and share typical benchmarks for testing Temporal Web and other Temporal utilities.
+
+This way, we can have an easy-to-reference baseline for PRs and communication.

--- a/temporal-fixtures/openNclosed/README.md
+++ b/temporal-fixtures/openNclosed/README.md
@@ -1,4 +1,4 @@
-This fixuture creates 20 workflows - 10 open, 10 closed:
+This fixuture creates 20 workflows - all either open for 10 minutes, or all either closed right away, depending on the `keep` flag:
 
 1. `keep` argument makes the workflow remain Open for 10 minutes if set to `true`, or otherwise the workflows will be quickly Close.
 2. Change the `Namespace: "default"` to another namespace for testing with a new set of data/runs 

--- a/temporal-fixtures/openNclosed/README.md
+++ b/temporal-fixtures/openNclosed/README.md
@@ -1,0 +1,8 @@
+This fixuture creates 20 workflows - 10 open, 10 closed:
+
+1. `keep` argument makes the workflow remain Open for 10 minutes if set to `true`, or otherwise the workflows will be quickly Close.
+2. Change the `Namespace: "default"` to another namespace for testing with a new set of data/runs 
+
+Used in:
+
+- https://github.com/temporalio/web/pull/315

--- a/temporal-fixtures/openNclosed/openNclosed.go
+++ b/temporal-fixtures/openNclosed/openNclosed.go
@@ -1,0 +1,40 @@
+package openNclosed
+
+import (
+	"context"
+	"time"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/workflow"
+)
+
+// Workflow is a Hello World workflow definition.
+func Workflow(ctx workflow.Context, name string, keep bool) (string, error) {
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: 10 * time.Second,
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	logger := workflow.GetLogger(ctx)
+	logger.Info("HelloWorld workflow started", "name", name)
+
+	var result string
+	err := workflow.ExecuteActivity(ctx, Activity, name, keep).Get(ctx, &result)
+	if err != nil {
+		logger.Error("Activity failed.", "Error", err)
+		return "", err
+	}
+
+	logger.Info("HelloWorld workflow completed.", "result", result)
+
+	return result, nil
+}
+
+func Activity(ctx context.Context, name string, keep bool) (string, error) {
+	logger := activity.GetLogger(ctx)
+	logger.Info("Activity", "name", name)
+	if keep {
+		time.Sleep(10 * time.Minute)
+	}
+	return "Hello " + name + "!", nil
+}

--- a/temporal-fixtures/openNclosed/starter/main.go
+++ b/temporal-fixtures/openNclosed/starter/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	// "fmt"
+	"log"
+
+	"github.com/pborman/uuid"
+	"github.com/temporalio/samples-go/temporal-fixtures/openNclosed"
+
+	"strconv"
+
+	"go.temporal.io/sdk/client"
+)
+
+func main() {
+	// The client is a heavyweight object that should be created once per process.
+	c, err := client.NewClient(client.Options{Namespace: "default"})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	uuidvar := uuid.New()
+	i := 1
+	for i <= 20 {
+		id := uuidvar[:8] + "###___" + strconv.Itoa(i)
+		i++
+
+		workflowOptions := client.StartWorkflowOptions{
+			ID:        id,
+			TaskQueue: "hello-world",
+		}
+
+		_, err := c.ExecuteWorkflow(context.Background(), workflowOptions, openNclosed.Workflow,
+			"Temporal", true)
+		if err != nil {
+			log.Fatalln("Unable to execute workflow", err)
+		}
+	}
+}

--- a/temporal-fixtures/openNclosed/worker/main.go
+++ b/temporal-fixtures/openNclosed/worker/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"log"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+
+	"github.com/temporalio/samples-go/temporal-fixtures/openNclosed"
+)
+
+func main() {
+	// The client and worker are heavyweight objects that should be created once per process.
+	c, err := client.NewClient(client.Options{
+		HostPort: client.DefaultHostPort,
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	w := worker.New(c, "retry-activity", worker.Options{})
+
+	w.RegisterWorkflow(openNclosed.Workflow)
+	w.RegisterActivity(openNclosed.Activity)
+
+	err = w.Run(worker.InterruptCh())
+	if err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+}


### PR DESCRIPTION
## What was changed:

added first temporal fixtures

## Why?

improve ease of manual testing and bug reproduction, make reusable, easy-to-reference examples

e.g., this PR https://github.com/temporalio/web/pull/315 could have said "manually tested with the `openNclosed` fixture" and this would be a commonly understood thing