### PR TITLE
Create large payloads fixture

### DIFF
--- a/temporal-fixtures/largepayload/README.md
+++ b/temporal-fixtures/largepayload/README.md
@@ -1,0 +1,4 @@
+This fixuture starts several workflows `(NumberOfWorkflows)` with payloads of size 1mb `(PayloadSize)`. These payloads include: memo, activity input, activity result.
+
+Used in:
+- Web UI performance testing

--- a/temporal-fixtures/largepayload/activities.go
+++ b/temporal-fixtures/largepayload/activities.go
@@ -1,0 +1,28 @@
+package largepayload
+
+import (
+	"context"
+	"math/rand"
+
+	"go.temporal.io/sdk/activity"
+)
+
+/**
+ * Sample activities used by large payloads fixture workflow.
+ */
+
+type Activities struct {
+}
+
+func (a *Activities) CreateLargeResultActivity(ctx context.Context, sizeBytes int) ([]byte, error) {
+	logger := activity.GetLogger(ctx)
+	logger.Info("Creating large result payload...", sizeBytes)
+
+	token := make([]byte, sizeBytes)
+	rand.Read(token)
+	return token, nil
+}
+
+func (a *Activities) ProcessLargeInputActivity(ctx context.Context, input []byte) error {
+	return nil
+}

--- a/temporal-fixtures/largepayload/starter/main.go
+++ b/temporal-fixtures/largepayload/starter/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"log"
+	"math/rand"
+	"strconv"
+
+	"github.com/pborman/uuid"
+	"github.com/temporalio/samples-go/temporal-fixtures/largepayload"
+	"go.temporal.io/sdk/client"
+)
+
+var (
+	NumberOfWorkflows = 5
+	PayloadSize       = 1 * 1024 * 1024
+)
+
+func main() {
+	// The client is a heavyweight object that should be created once per process.
+	c, err := client.NewClient(client.Options{
+		HostPort: client.DefaultHostPort,
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	id := uuid.New()[0:4]
+
+	memoToken := make([]byte, PayloadSize)
+	rand.Read(memoToken)
+
+	i := 1
+	for i <= NumberOfWorkflows {
+		workflowOptions := client.StartWorkflowOptions{
+			ID:        "largepayload_" + id + "_" + strconv.Itoa(i),
+			TaskQueue: "largepayload",
+			Memo:      map[string]interface{}{"attr1": memoToken},
+		}
+
+		we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, largepayload.LargePayloadWorkflow, PayloadSize)
+		if err != nil {
+			log.Fatalln("Unable to execute workflow", err)
+		}
+		log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
+		i++
+	}
+}

--- a/temporal-fixtures/largepayload/worker/main.go
+++ b/temporal-fixtures/largepayload/worker/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"log"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+
+	"github.com/temporalio/samples-go/temporal-fixtures/largepayload"
+)
+
+func main() {
+	// The client and worker are heavyweight objects that should be created once per process.
+	c, err := client.NewClient(client.Options{
+		HostPort: client.DefaultHostPort,
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	w := worker.New(c, "largepayload", worker.Options{})
+
+	w.RegisterWorkflow(largepayload.LargePayloadWorkflow)
+	w.RegisterActivity(&largepayload.Activities{})
+
+	err = w.Run(worker.InterruptCh())
+	if err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+}

--- a/temporal-fixtures/largepayload/workflow.go
+++ b/temporal-fixtures/largepayload/workflow.go
@@ -1,0 +1,31 @@
+package largepayload
+
+import (
+	"time"
+
+	"go.temporal.io/sdk/workflow"
+)
+
+// LargePayloadWorkflow workflow definition
+func LargePayloadWorkflow(ctx workflow.Context, payloadSize int) (err error) {
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: time.Minute,
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	var data []byte
+	var a *Activities
+	err = workflow.ExecuteActivity(ctx, a.CreateLargeResultActivity, payloadSize).Get(ctx, &data)
+	if err != nil {
+		return err
+	}
+
+	err = workflow.ExecuteActivity(ctx, a.ProcessLargeInputActivity, data).Get(ctx, nil)
+
+	if err != nil {
+		workflow.GetLogger(ctx).Error("Workflow failed.", "Error", err.Error())
+	} else {
+		workflow.GetLogger(ctx).Info("Workflow completed.")
+	}
+	return err
+}

--- a/temporal-fixtures/largepayload/workflow_test.go
+++ b/temporal-fixtures/largepayload/workflow_test.go
@@ -1,0 +1,37 @@
+package largepayload
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/worker"
+
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/testsuite"
+)
+
+type UnitTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+}
+
+func TestUnitTestSuite(t *testing.T) {
+	suite.Run(t, new(UnitTestSuite))
+}
+
+func (s *UnitTestSuite) Test_LargePayloadWorkflow() {
+	env := s.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(worker.Options{})
+	var a *Activities
+
+	data := []byte{}
+	env.OnActivity(a.CreateLargeResultActivity, mock.Anything, 1*1024).Return(data, nil)
+	env.OnActivity(a.ProcessLargeInputActivity, mock.Anything, data).Return(nil)
+
+	env.RegisterActivity(a)
+
+	env.ExecuteWorkflow(LargePayloadWorkflow, 1*1024)
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
<!-- Describe what has changed in this PR -->
Added a fixture to reproduce cases of large workflow payload sizes and large gRPC messages

## Why?
<!-- Tell your future self why have you made these changes -->
Allows to easily reproduce cases of gRPC message size limitations, large memo, input and result fields. Useful at testing Web UI and its performance

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Added new unit test + ran the fixture

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
no