### PR TITLE
Add an example of a compressing data converter.

### DIFF
--- a/compression-converter/README.md
+++ b/compression-converter/README.md
@@ -1,0 +1,20 @@
+### Steps to run this sample:
+1) You need a Temporal service running. See details in README.md
+2) Compile the compressionconverter plugin for tctl
+```
+go build -o ../bin/compressionconverter-plugin plugin/main.go
+```
+3) Run the following command to start the worker
+```
+go run worker/main.go
+```
+4) Run the following command to start the example
+```
+go run starter/main.go
+```
+5) Run the following command and see the encrypted payloads
+```
+export PATH="../bin:$PATH" TEMPORAL_CLI_PLUGIN_DATA_CONVERTER=compressionconverter-plugin
+tctl workflow show --wid compressionconverter_workflowID
+```
+Note: plugins should normally be available in your PATH, we include the current directory in the path here for ease of testing.

--- a/compression-converter/data-converter.go
+++ b/compression-converter/data-converter.go
@@ -1,0 +1,187 @@
+package compressionconverter
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	commonpb "go.temporal.io/api/common/v1"
+
+	"go.temporal.io/sdk/converter"
+
+	"github.com/pierrec/lz4"
+)
+
+const (
+	// MetadataCompressionAlgorithmKey is "compression-algorithm"
+	MetadataCompressionAlgorithmKey = "compression-algorithm"
+
+	// MetadataCompressionAlgorithm is "lz4"
+	MetadataCompressionAlgorithm = "lz4"
+
+	// MetadataEncodingCompressed is "binary/compressed"
+	MetadataEncodingCompressed = "binary/compressed"
+)
+
+// CompressionConverter implements a DataConverter using LZ4.
+type CompressionConverter struct {
+	dataConverter converter.DataConverter
+}
+
+// NewCompressionConverter creates a new instance of CompressionConvertter wrapping a DataConverter
+func NewCompressionConverter(dataConverter converter.DataConverter) *CompressionConverter {
+	return &CompressionConverter{
+		dataConverter: dataConverter,
+	}
+}
+
+// ToPayloads converts a list of values.
+func (dc *CompressionConverter) ToPayloads(values ...interface{}) (*commonpb.Payloads, error) {
+	result := &commonpb.Payloads{}
+
+	for i, value := range values {
+		payload, err := dc.dataConverter.ToPayload(value)
+		if err != nil {
+			return nil, fmt.Errorf("values[%d]: %w", i, err)
+		}
+
+		payload, err = dc.compressPayload(payload)
+		if err != nil {
+			return nil, fmt.Errorf("values[%d]: %w", i, err)
+		}
+
+		result.Payloads = append(result.Payloads, payload)
+	}
+
+	return result, nil
+}
+
+func (dc *CompressionConverter) compressPayload(payload *commonpb.Payload) (*commonpb.Payload, error) {
+	serializedPayload, err := payload.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", converter.ErrUnableToEncode, err)
+	}
+
+	var compressedPayload bytes.Buffer
+
+	w := lz4.NewWriter(&compressedPayload)
+	_, err = w.Write(serializedPayload)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", converter.ErrUnableToEncode, err)
+	}
+	err = w.Close()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", converter.ErrUnableToEncode, err)
+	}
+
+	return &commonpb.Payload{
+		Metadata: map[string][]byte{
+			converter.MetadataEncoding:      []byte(MetadataEncodingCompressed),
+			MetadataCompressionAlgorithmKey: []byte(MetadataCompressionAlgorithm),
+		},
+		Data: compressedPayload.Bytes(),
+	}, nil
+}
+
+// ToPayload converts single value to payload.
+func (dc *CompressionConverter) ToPayload(value interface{}) (*commonpb.Payload, error) {
+	return dc.dataConverter.ToPayload(value)
+}
+
+func isCompressedPayload(payload *commonpb.Payload) bool {
+	metadata := payload.GetMetadata()
+	if metadata == nil {
+		return false
+	}
+
+	if encoding, ok := metadata[converter.MetadataEncoding]; ok {
+		return string(encoding) == MetadataEncodingCompressed
+	}
+
+	return false
+}
+
+// FromPayloads converts to a list of values of different types.
+func (dc *CompressionConverter) FromPayloads(payloads *commonpb.Payloads, valuePtrs ...interface{}) error {
+	for i, payload := range payloads.GetPayloads() {
+		var err error
+
+		if i >= len(valuePtrs) {
+			break
+		}
+
+		if isCompressedPayload(payload) {
+			payload, err = dc.decompressPayload(payload)
+			if err != nil {
+				return fmt.Errorf("args[%d]: %w", i, err)
+			}
+		}
+
+		err = dc.dataConverter.FromPayload(payload, valuePtrs[i])
+		if err != nil {
+			return fmt.Errorf("args[%d]: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+func (dc *CompressionConverter) decompressPayload(payload *commonpb.Payload) (*commonpb.Payload, error) {
+	metadata := payload.GetMetadata()
+	if metadata == nil {
+		return nil, converter.ErrMetadataIsNotSet
+	}
+
+	algorithm, ok := metadata[MetadataCompressionAlgorithmKey]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", converter.ErrUnableToDecode, "no compression algorithm metadata")
+	}
+
+	if string(algorithm) != MetadataCompressionAlgorithm {
+		return nil, fmt.Errorf("%w: %s '%s'", converter.ErrUnableToDecode, "unsupported compression algorithm", algorithm)
+	}
+
+	var uncompressedPayload bytes.Buffer
+
+	r := lz4.NewReader(bytes.NewReader(payload.GetData()))
+	_, err := io.Copy(&uncompressedPayload, r)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", converter.ErrUnableToDecode, err)
+	}
+
+	result := &commonpb.Payload{}
+	err = result.Unmarshal(uncompressedPayload.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", converter.ErrUnableToDecode, err)
+	}
+
+	return result, nil
+}
+
+// FromPayload converts single value from payload.
+func (dc *CompressionConverter) FromPayload(payload *commonpb.Payload, valuePtr interface{}) error {
+	return dc.dataConverter.FromPayload(payload, valuePtr)
+}
+
+// ToStrings converts payloads object into human readable strings.
+func (dc *CompressionConverter) ToStrings(payloads *commonpb.Payloads) []string {
+	var result []string
+	for _, payload := range payloads.GetPayloads() {
+		result = append(result, dc.ToString(payload))
+	}
+
+	return result
+}
+
+// ToString converts payload object into human readable string.
+func (dc *CompressionConverter) ToString(payload *commonpb.Payload) string {
+	if isCompressedPayload(payload) {
+		var err error
+		payload, err = dc.decompressPayload(payload)
+		if err != nil {
+			return err.Error()
+		}
+	}
+
+	return dc.dataConverter.ToString(payload)
+}

--- a/compression-converter/plugin/main.go
+++ b/compression-converter/plugin/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/hashicorp/go-plugin"
+	compressionconverter "github.com/temporalio/samples-go/compression-converter"
+	"go.temporal.io/sdk/converter"
+	cliplugin "go.temporal.io/server/tools/cli/plugin"
+)
+
+func main() {
+	var pluginMap = map[string]plugin.Plugin{
+		cliplugin.DataConverterPluginType: &cliplugin.DataConverterPlugin{
+			Impl: compressionconverter.NewCompressionConverter(
+				converter.GetDefaultDataConverter(),
+			),
+		},
+	}
+
+	plugin.Serve(&plugin.ServeConfig{
+		HandshakeConfig: cliplugin.PluginHandshakeConfig,
+		Plugins:         pluginMap,
+	})
+}

--- a/compression-converter/starter/main.go
+++ b/compression-converter/starter/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	compressionconverter "github.com/temporalio/samples-go/compression-converter"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/converter"
+)
+
+func main() {
+	// The client is a heavyweight object that should be created once per process.
+	c, err := client.NewClient(client.Options{
+		// Set DataConverter here to ensure that workflow inputs and results are
+		// compressed/decompressed as required.
+		DataConverter: compressionconverter.NewCompressionConverter(
+			converter.GetDefaultDataConverter(),
+		),
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	workflowOptions := client.StartWorkflowOptions{
+		ID:        "compressionconverter_workflowID",
+		TaskQueue: "compressionconverter",
+	}
+
+	ctx := context.Background()
+
+	// The workflow input "Hello" will be compressed by the DataConverter before being sent to Temporal
+	we, err := c.ExecuteWorkflow(
+		ctx,
+		workflowOptions,
+		compressionconverter.Workflow,
+		"My Friend",
+	)
+	if err != nil {
+		log.Fatalln("Unable to execute workflow", err)
+	}
+
+	log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
+
+	// Synchronously wait for the workflow completion.
+	var result string
+	err = we.Get(context.Background(), &result)
+	if err != nil {
+		log.Fatalln("Unable get workflow result", err)
+	}
+	log.Println("Workflow result:", result)
+}

--- a/compression-converter/worker/main.go
+++ b/compression-converter/worker/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"log"
+
+	compressionconverter "github.com/temporalio/samples-go/compression-converter"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/worker"
+)
+
+func main() {
+	// The client and worker are heavyweight objects that should be created once per process.
+	c, err := client.NewClient(client.Options{
+		// Set DataConverter here so that workflow and activity inputs/results can
+		// be compressed/decompressed as required.
+		DataConverter: compressionconverter.NewCompressionConverter(
+			converter.GetDefaultDataConverter(),
+		),
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	w := worker.New(c, "compressionconverter", worker.Options{})
+
+	w.RegisterWorkflow(compressionconverter.Workflow)
+	w.RegisterActivity(compressionconverter.Activity)
+
+	err = w.Run(worker.InterruptCh())
+	if err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+}

--- a/compression-converter/workflow.go
+++ b/compression-converter/workflow.go
@@ -1,0 +1,49 @@
+package compressionconverter
+
+import (
+	"context"
+	"time"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/workflow"
+)
+
+// Workflow is a standard workflow definition.
+// Note that the Workflow and Activity don't need to care that
+// their inputs/results are being compressed/decompressed.
+func Workflow(ctx workflow.Context, name string) (string, error) {
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: 10 * time.Second,
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	logger := workflow.GetLogger(ctx)
+	logger.Info("Compressed Payloads workflow started", "name", name)
+
+	info := map[string]string{
+		"name": name,
+	}
+
+	var result string
+	err := workflow.ExecuteActivity(ctx, Activity, info).Get(ctx, &result)
+	if err != nil {
+		logger.Error("Activity failed.", "Error", err)
+		return "", err
+	}
+
+	logger.Info("Compressed Payloads workflow completed.", "result", result)
+
+	return result, nil
+}
+
+func Activity(ctx context.Context, info map[string]string) (string, error) {
+	logger := activity.GetLogger(ctx)
+	logger.Info("Activity", "info", info)
+
+	name, ok := info["name"]
+	if !ok {
+		name = "someone"
+	}
+
+	return "Hello " + name + "!", nil
+}

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,13 @@ go 1.16
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v0.9.0 // indirect
+	github.com/frankban/quicktest v1.13.0 // indirect
 	github.com/golang/mock v1.5.0
 	github.com/hashicorp/go-plugin v1.4.0
 	github.com/m3db/prometheus_client_golang v0.8.1
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pborman/uuid v1.2.1
+	github.com/pierrec/lz4 v2.6.1+incompatible
 	github.com/stretchr/testify v1.7.0
 	github.com/uber-go/tally v3.3.17+incompatible
 	github.com/uber/jaeger-client-go v2.25.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/frankban/quicktest v1.13.0 h1:yNZif1OkDfNoDfb9zZa9aXIpejNR4F23Wely0c+Qdqk=
+github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/r/VLSOOIySU=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -222,6 +224,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -270,6 +273,8 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
+github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
+github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
The example uses LZ4 but is easily changed to use any format.

## What was changed
I added an example of a data converter implementing compression for inputs/results.

## Why?
Users may find it useful if they are pushing up against payload size limits or want to ease database storage costs, trading off for some performance for the compression.