### PR TITLE
tweak openNclosed fixture

### DIFF
--- a/temporal-fixtures/openNclosed/openNclosed.go
+++ b/temporal-fixtures/openNclosed/openNclosed.go
@@ -8,29 +8,29 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
-// Workflow is a Hello World workflow definition.
-func Workflow(ctx workflow.Context, name string, keep bool) (string, error) {
+// OpenClosedFixtureWorkflow is a basic Hello World workflow definition.
+func OpenClosedFixtureWorkflow(ctx workflow.Context, name string, keep bool) (string, error) {
 	ao := workflow.ActivityOptions{
 		StartToCloseTimeout: 10 * time.Second,
 	}
 	ctx = workflow.WithActivityOptions(ctx, ao)
 
 	logger := workflow.GetLogger(ctx)
-	logger.Info("HelloWorld workflow started", "name", name)
+	logger.Info("OpenClosedFixtureWorkflow started", "name", name)
 
 	var result string
-	err := workflow.ExecuteActivity(ctx, Activity, name, keep).Get(ctx, &result)
+	err := workflow.ExecuteActivity(ctx, OpenClosedFixtureActivity, name, keep).Get(ctx, &result)
 	if err != nil {
 		logger.Error("Activity failed.", "Error", err)
 		return "", err
 	}
 
-	logger.Info("HelloWorld workflow completed.", "result", result)
+	logger.Info("OpenClosedFixtureWorkflow completed.", "result", result)
 
 	return result, nil
 }
 
-func Activity(ctx context.Context, name string, keep bool) (string, error) {
+func OpenClosedFixtureActivity(ctx context.Context, name string, keep bool) (string, error) {
 	logger := activity.GetLogger(ctx)
 	logger.Info("Activity", "name", name)
 	if keep {

--- a/temporal-fixtures/openNclosed/starter/main.go
+++ b/temporal-fixtures/openNclosed/starter/main.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	NumberOfWorkflows = 5
-	KeepOpen          = true
+	KeepOpen          = false
 )
 
 func main() {
@@ -29,7 +29,7 @@ func main() {
 	uuidvar := uuid.New()
 	i := 1
 	for i <= NumberOfWorkflows {
-		id := uuidvar[:8] + "###___" + strconv.Itoa(i)
+		id := "open-n-closed##" + uuidvar[:6] + "##" + strconv.Itoa(i)
 		i++
 
 		workflowOptions := client.StartWorkflowOptions{
@@ -37,7 +37,7 @@ func main() {
 			TaskQueue: "open-n-closed",
 		}
 
-		_, err := c.ExecuteWorkflow(context.Background(), workflowOptions, openNclosed.Workflow,
+		_, err := c.ExecuteWorkflow(context.Background(), workflowOptions, openNclosed.OpenClosedFixtureWorkflow,
 			"Temporal", KeepOpen)
 		if err != nil {
 			log.Fatalln("Unable to execute workflow", err)

--- a/temporal-fixtures/openNclosed/worker/main.go
+++ b/temporal-fixtures/openNclosed/worker/main.go
@@ -21,8 +21,8 @@ func main() {
 
 	w := worker.New(c, "open-n-closed", worker.Options{})
 
-	w.RegisterWorkflow(openNclosed.Workflow)
-	w.RegisterActivity(openNclosed.Activity)
+	w.RegisterWorkflow(openNclosed.OpenClosedFixtureWorkflow)
+	w.RegisterActivity(openNclosed.OpenClosedFixtureActivity)
 
 	err = w.Run(worker.InterruptCh())
 	if err != nil {


### PR DESCRIPTION
## What was changed

Proposing a small tweak to fixture to make it more readable if you are running other fixtures alongside it.

<img width="1222" alt="CleanShot 2021-07-20 at 18 00 27@2x" src="https://user-images.githubusercontent.com/6764957/126414038-860403cd-dd86-4348-82f3-be2214c804bb.png">


## Why?
i'm running more fixtures and a workflow called "Workflow" isnt' very helpful