### PR TITLE
Create fixture with stuck workflows

### DIFF
--- a/temporal-fixtures/stuck-workflows/README.md
+++ b/temporal-fixtures/stuck-workflows/README.md
@@ -1,0 +1,8 @@
+This fixuture starts few stuck workflows:
+
+- no running worker that would listen to workflow's task queue
+- activity that fails and is being infinitely retried
+
+Used in:
+
+- Web UI development

--- a/temporal-fixtures/stuck-workflows/starter/main.go
+++ b/temporal-fixtures/stuck-workflows/starter/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/pborman/uuid"
+	"go.temporal.io/sdk/client"
+
+	stuckworkflows "github.com/temporalio/samples-go/temporal-fixtures/stuck-workflows"
+)
+
+func main() {
+	// The client is a heavyweight object that should be created once per process.
+	c, err := client.NewClient(client.Options{
+		HostPort: client.DefaultHostPort,
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	id := uuid.New()[:6]
+
+	workflowOptions := client.StartWorkflowOptions{
+		ID:        id + "_" + "stuck_activity",
+		TaskQueue: "stuck-workflows",
+	}
+
+	we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, stuckworkflows.StuckWorkflow)
+	if err != nil {
+		log.Fatalln("Unable to execute workflow", err)
+	} else {
+		log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
+	}
+
+	workflowOptions = client.StartWorkflowOptions{
+		ID:        id + "_" + "no_worker",
+		TaskQueue: "no-worker",
+	}
+
+	we, err = c.ExecuteWorkflow(context.Background(), workflowOptions, stuckworkflows.StuckWorkflow)
+	if err != nil {
+		log.Fatalln("Unable to execute workflow", err)
+	} else {
+		log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
+	}
+}

--- a/temporal-fixtures/stuck-workflows/worker/main.go
+++ b/temporal-fixtures/stuck-workflows/worker/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"log"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+
+	stuckworkflows "github.com/temporalio/samples-go/temporal-fixtures/stuck-workflows"
+)
+
+func main() {
+	// The client and worker are heavyweight objects that should be created once per process.
+	c, err := client.NewClient(client.Options{
+		HostPort: client.DefaultHostPort,
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	w := worker.New(c, "stuck-workflows", worker.Options{})
+
+	w.RegisterWorkflow(stuckworkflows.StuckWorkflow)
+	w.RegisterActivity(stuckworkflows.StuckWorkflowActivity)
+
+	err = w.Run(worker.InterruptCh())
+	if err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+}

--- a/temporal-fixtures/stuck-workflows/workflow.go
+++ b/temporal-fixtures/stuck-workflows/workflow.go
@@ -1,0 +1,48 @@
+package stuckworkflows
+
+import (
+	"context"
+	"time"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+/**
+ * This sample workflow executes unreliable activity with retry policy. If activity execution failed, server will
+ * schedule retry based on retry policy configuration. The activity also heartbeatы progress so it could resume from
+ * reported progress in the retry attempts.
+ */
+
+// StuckWorkflow workflow definition
+func StuckWorkflow(ctx workflow.Context) error {
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: 24 * time.Hour,
+		HeartbeatTimeout:    10 * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    time.Minute,
+			MaximumAttempts:    0,
+		},
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	err := workflow.ExecuteActivity(ctx, StuckWorkflowActivity).Get(ctx, nil)
+	if err != nil {
+		workflow.GetLogger(ctx).Info("Workflow completed with error.", "Error", err)
+		return err
+	}
+	workflow.GetLogger(ctx).Info("Workflow completed.")
+	return nil
+}
+
+// StuckWorkflowActivity process batchSize of jobs starting from firstTaskID. This activity will heartbeat to report
+// progress, and it could fail sometimes. Use retry policy to retry when it failed, and resume from reported progress.
+func StuckWorkflowActivity(ctx context.Context) error {
+	logger := activity.GetLogger(ctx)
+
+	logger.Info("Activity failed, will retry...")
+	return temporal.NewApplicationError("some retryable error", "SomeType")
+}

--- a/temporal-fixtures/stuck-workflows/workflow_test.go
+++ b/temporal-fixtures/stuck-workflows/workflow_test.go
@@ -1,0 +1,34 @@
+package stuckworkflows
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/worker"
+
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/testsuite"
+)
+
+type UnitTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+}
+
+func TestUnitTestSuite(t *testing.T) {
+	suite.Run(t, new(UnitTestSuite))
+}
+
+func (s *UnitTestSuite) Test_LargePayloadWorkflow() {
+	env := s.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(worker.Options{})
+
+	env.OnActivity(StuckWorkflowActivity, mock.Anything).Return(nil)
+
+	env.RegisterActivity(StuckWorkflowActivity)
+
+	env.ExecuteWorkflow(StuckWorkflow)
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds a new fixture that starts few workflows stuck because:

- no running worker that would listen to workflow's task queue
- activity that fails and is being infinitely retried
- 
## Why?
<!-- Tell your future self why have you made these changes -->
Helps with Web UI development

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
ran and verified through Web UI

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
no docs update needed