### PR TITLE
Signal only running workflows in workflows fixture

### DIFF
--- a/temporal-fixtures/rainbow-statuses/README.md
+++ b/temporal-fixtures/rainbow-statuses/README.md
@@ -2,7 +2,7 @@ This fixuture starts few sets of workflows (`NumberOfSets`)
 
  - each set contains workflows of each Status (ie. Open, Terminated, ..)
  - each workflow contains custom search attributes
- - each workflow receives a signal
+ - running workflows receive a signal
 
 Used in:
 

--- a/temporal-fixtures/rainbow-statuses/starter/main.go
+++ b/temporal-fixtures/rainbow-statuses/starter/main.go
@@ -76,12 +76,14 @@ func main() {
 				}
 			}
 
-			signal := struct {
-				Hey string
-				At  time.Time
-			}{"from Mars", time.Now()}
-			if err = c.SignalWorkflow(context.Background(), w.GetID(), w.GetRunID(), "customSignal", signal); err != nil {
-				log.Fatalln("unable to signal workflow", err)
+			if s == enums.WORKFLOW_EXECUTION_STATUS_RUNNING {
+				signal := struct {
+					Hey string
+					At  time.Time
+				}{"from Mars", time.Now()}
+				if err = c.SignalWorkflow(context.Background(), w.GetID(), w.GetRunID(), "customSignal", signal); err != nil {
+					log.Fatalln("unable to signal workflow", err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Signals only running workflows in a fixture, not all 

## Why?
<!-- Tell your future self why have you made these changes -->
Fixes an issue that the workflows fixture would fail before starting all of the workflows

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
ran the fixture on with `NumberOfSets` = 5
verified workflows are started and have expected statuses through web ui
verified only running workflwos have signal event

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
no