### PR TITLE
Updatabletimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Each sample demonstrates one feature of the SDK, together with tests.
 
 - [**Tracing and Context Propagation**](https://github.com/temporalio/samples-go/tree/master/ctxpropagation): Demonstrates  the client initialization with a context propagator, which propagates specific information in the `context.Context` object across the Workflow Execution. The `context.Context` object is populated with information prior to calling `StartWorkflow`. This example demonstrates that the information is available in the Workflow Execution and Activity Executions. Additional documentation: [How to use tracing in Go](https://docs.temporal.io/docs/go/tracing/).
 
+- [**Updatable Timer**](https://github.com/temporalio/samples-go/tree/master/updatabletimer): Demonstrates timer cancellation and use of a Selector to wait on a Future and a Channel simultaneously. 
+
 ### Dynamic Workflow logic examples
 
 These samples demonstrate some common control flow patterns using Temporal's Go SDK API.

--- a/branch/activity.go
+++ b/branch/activity.go
@@ -3,6 +3,7 @@ package branch
 import (
 	"fmt"
 )
+
 // @@@SNIPSTART samples-go-branch-activity-definition
 // SampleActivity is a Temporal Activity Definition
 func SampleActivity(input string) (string, error) {
@@ -10,4 +11,5 @@ func SampleActivity(input string) (string, error) {
 	fmt.Printf("Run %s with input %v \n", name, input)
 	return "Result_" + input, nil
 }
+
 // @@@SNIPEND

--- a/branch/starter/main.go
+++ b/branch/starter/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/temporalio/samples-go/branch"
 )
+
 // @@@SNIPSTART samples-go-branch-workflow-execution-starter
 func main() {
 	// The client is a heavyweight object that should be created only once per process.
@@ -36,4 +37,5 @@ func main() {
 	}
 	log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
 }
+
 // @@@SNIPEND

--- a/branch/worker/main.go
+++ b/branch/worker/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/temporalio/samples-go/branch"
 )
+
 // @@@SNIPSTART samples-go-branch-worker-starter
 func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
@@ -29,4 +30,5 @@ func main() {
 		log.Fatalln("Unable to start worker", err)
 	}
 }
+
 // @@@SNIPEND

--- a/branch/workflow.go
+++ b/branch/workflow.go
@@ -6,6 +6,7 @@ import (
 
 	"go.temporal.io/sdk/workflow"
 )
+
 // @@@SNIPSTART samples-go-branch-workflow-definition
 // SampleBranchWorkflow is a Temporal Workflow Definition
 // This Workflow Definition shows how to call multiple Activities in parallel.
@@ -41,4 +42,5 @@ func SampleBranchWorkflow(ctx workflow.Context, totalBranches int) (result []str
 	logger.Info("SampleBranchWorkflow end")
 	return
 }
+
 // @@@SNIPEND

--- a/branch/workflow_test.go
+++ b/branch/workflow_test.go
@@ -36,4 +36,5 @@ func (s *UnitTestSuite) Test_BranchWorkflow() {
 	sort.Strings(expected)
 	s.Equal(expected, result)
 }
+
 // @@@SNIPEND

--- a/cancellation/activity.go
+++ b/cancellation/activity.go
@@ -6,8 +6,9 @@ import (
 
 	"go.temporal.io/sdk/activity"
 )
+
 // @@@SNIPSTART samples-go-cancellation-activity-definition
-type Activities struct {}
+type Activities struct{}
 
 func (a *Activities) ActivityToBeCanceled(ctx context.Context) (string, error) {
 	logger := activity.GetLogger(ctx)
@@ -36,4 +37,5 @@ func (a *Activities) ActivityToBeSkipped(ctx context.Context) error {
 	logger.Info("this Activity will be skipped due to cancellation")
 	return nil
 }
+
 // @@@SNIPEND

--- a/cancellation/cancel/main.go
+++ b/cancellation/cancel/main.go
@@ -7,6 +7,7 @@ import (
 
 	"go.temporal.io/sdk/client"
 )
+
 // @@@SNIPSTART samples-go-cancellation-cancel-workflow-execution-trigger
 func main() {
 	var workflowID string
@@ -33,4 +34,5 @@ func main() {
 	}
 	log.Println("Workflow Execution cancelled", "WorkflowID", workflowID)
 }
+
 // @@@SNIPEND

--- a/cancellation/starter/main.go
+++ b/cancellation/starter/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/temporalio/samples-go/cancellation"
 )
+
 // @@@SNIPSTART samples-go-cancellation-workflow-execution-starter
 func main() {
 	var workflowID string
@@ -35,4 +36,5 @@ func main() {
 	}
 	log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
 }
+
 // @@@SNIPEND

--- a/cancellation/worker/main.go
+++ b/cancellation/worker/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/temporalio/samples-go/cancellation"
 )
+
 // @@@SNIPSTART samples-go-cancellation-worker-starter
 func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
@@ -29,4 +30,5 @@ func main() {
 		log.Fatalln("Unable to start worker", err)
 	}
 }
+
 // @@@SNIPEND

--- a/cancellation/workflow.go
+++ b/cancellation/workflow.go
@@ -6,6 +6,7 @@ import (
 
 	"go.temporal.io/sdk/workflow"
 )
+
 // @@@SNIPSTART samples-go-cancellation-workflow-definition
 // YourWorkflow is a Workflow Definition that shows how it can be canceled.
 func YourWorkflow(ctx workflow.Context) error {

--- a/child-workflow-continue-as-new/child_workflow.go
+++ b/child-workflow-continue-as-new/child_workflow.go
@@ -6,6 +6,7 @@ import (
 
 	"go.temporal.io/sdk/workflow"
 )
+
 // @@@SNIPSTART samples-go-cw-cas-child-workflow-definition
 // SampleChildWorkflow is a Workflow Definition
 func SampleChildWorkflow(ctx workflow.Context, totalCount, runCount int) (string, error) {
@@ -27,4 +28,5 @@ func SampleChildWorkflow(ctx workflow.Context, totalCount, runCount int) (string
 	logger.Info("Child workflow starting new run.", "RunCount", runCount, "TotalCount", totalCount)
 	return "", workflow.NewContinueAsNewError(ctx, SampleChildWorkflow, totalCount, runCount)
 }
+
 // @@@SNIPEND

--- a/child-workflow-continue-as-new/parent_workflow.go
+++ b/child-workflow-continue-as-new/parent_workflow.go
@@ -5,6 +5,7 @@ import (
 
 	"go.temporal.io/sdk/workflow"
 )
+
 // @@@SNIPSTART samples-go-cw-cas-parent-workflow-definition
 // SampleParentWorkflow is a Workflow Definition
 func SampleParentWorkflow(ctx workflow.Context) error {
@@ -28,4 +29,5 @@ func SampleParentWorkflow(ctx workflow.Context) error {
 	logger.Info("Parent execution completed.", "Result", result)
 	return nil
 }
+
 // @@@SNIPEND

--- a/child-workflow-continue-as-new/starter/main.go
+++ b/child-workflow-continue-as-new/starter/main.go
@@ -9,6 +9,7 @@ import (
 
 	cw "github.com/temporalio/samples-go/child-workflow-continue-as-new"
 )
+
 // @@@SNIPSTART samples-go-cw-cas-workflow-execution-starter
 func main() {
 	// The client is a heavyweight object that should be created once per process.
@@ -33,4 +34,5 @@ func main() {
 	}
 	log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
 }
+
 // @@@SNIPEND

--- a/child-workflow-continue-as-new/worker/main.go
+++ b/child-workflow-continue-as-new/worker/main.go
@@ -8,6 +8,7 @@ import (
 
 	cw "github.com/temporalio/samples-go/child-workflow-continue-as-new"
 )
+
 // @@@SNIPSTART samples-go-cw-cas-worker-starter
 func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
@@ -29,4 +30,5 @@ func main() {
 		log.Fatalln("Unable to start worker", err)
 	}
 }
+
 // @@@SNIPEND

--- a/child-workflow/child_workflow.go
+++ b/child-workflow/child_workflow.go
@@ -3,6 +3,7 @@ package child_workflow
 import (
 	"go.temporal.io/sdk/workflow"
 )
+
 // @@@SNIPSTART samples-go-child-workflow-example-child-workflow-definition
 // SampleChildWorkflow is a Workflow Definition
 func SampleChildWorkflow(ctx workflow.Context, name string) (string, error) {
@@ -11,4 +12,5 @@ func SampleChildWorkflow(ctx workflow.Context, name string) (string, error) {
 	logger.Info("Child workflow execution: " + greeting)
 	return greeting, nil
 }
+
 // @@@SNIPEND

--- a/child-workflow/parent_workflow.go
+++ b/child-workflow/parent_workflow.go
@@ -3,6 +3,7 @@ package child_workflow
 import (
 	"go.temporal.io/sdk/workflow"
 )
+
 // @@@SNIPSTART samples-go-child-workflow-example-parent-workflow-definition
 // SampleParentWorkflow is a Workflow Definition
 // This Workflow Definition demonstrates how to start a Child Workflow Execution from a Parent Workflow Execution.
@@ -26,4 +27,5 @@ func SampleParentWorkflow(ctx workflow.Context) (string, error) {
 	logger.Info("Parent execution completed.", "Result", result)
 	return result, nil
 }
+
 // @@@SNIPEND

--- a/child-workflow/starter/main.go
+++ b/child-workflow/starter/main.go
@@ -9,6 +9,7 @@ import (
 
 	child_workflow "github.com/temporalio/samples-go/child-workflow"
 )
+
 // @@@SNIPSTART samples-go-child-workflow-example-execution-starter
 func main() {
 	// The client is a heavyweight object that should be created only once per process.
@@ -45,4 +46,5 @@ func main() {
 	}
 	log.Println("Workflow result: %v", "result", result)
 }
+
 // @@@SNIPEND

--- a/child-workflow/worker/main.go
+++ b/child-workflow/worker/main.go
@@ -8,6 +8,7 @@ import (
 
 	child_workflow "github.com/temporalio/samples-go/child-workflow"
 )
+
 // @@@SNIPSTART samples-go-child-workflow-example-worker-starter
 func main() {
 	// The client is a heavyweight object that should be created only once per process.
@@ -29,4 +30,5 @@ func main() {
 		log.Fatalln("Unable to start worker", err)
 	}
 }
+
 // @@@SNIPEND

--- a/updatabletimer/README.md
+++ b/updatabletimer/README.md
@@ -1,0 +1,10 @@
+### Steps to run this sample:
+1) You need a Temporal service running. See details in README.md
+2) Run the following command to start the worker
+```
+go run timer/worker/main.go
+```
+3) Run the following command to start the example
+```
+go run timer/starter/main.go
+```

--- a/updatabletimer/README.md
+++ b/updatabletimer/README.md
@@ -1,10 +1,30 @@
+# Updatable Timer Sample
+
+A helper structure that supports blocking sleep that can be rescheduled at any moment.
+
+Demonstrates:
+
+* Timer and its cancellation
+* Signal Channel
+* Selector used to wait on both timer and channel
+
 ### Steps to run this sample:
+
 1) You need a Temporal service running. See details in README.md
 2) Run the following command to start the worker
+
 ```
-go run timer/worker/main.go
+go run updatabletimer/worker/main.go
 ```
+
 3) Run the following command to start the example
+
 ```
-go run timer/starter/main.go
+go run updatabletimer/starter/main.go
+```
+
+4)  Run the following command to update the timer wake-up time
+
+```
+go run updatabletimer/updater/main.go
 ```

--- a/updatabletimer/starter/main.go
+++ b/updatabletimer/starter/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/pborman/uuid"
+	"go.temporal.io/sdk/client"
+
+	"github.com/temporalio/samples-go/timer"
+)
+
+func main() {
+	// The client is a heavyweight object that should be created once per process.
+	c, err := client.NewClient(client.Options{
+		HostPort: client.DefaultHostPort,
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	workflowOptions := client.StartWorkflowOptions{
+		ID:        "timer_" + uuid.New(),
+		TaskQueue: "timer",
+	}
+
+	we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, timer.SampleTimerWorkflow, time.Second*3)
+	if err != nil {
+		log.Fatalln("Unable to execute workflow", err)
+	}
+	log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
+}

--- a/updatabletimer/updater/main.go
+++ b/updatabletimer/updater/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"github.com/temporalio/samples-go/updatabletimer"
+	"log"
+	"time"
+
+	"go.temporal.io/sdk/client"
+)
+
+// Signals updatable timer workflow to change wake-up time to 20 seconds from now.
+func main() {
+	// The client is a heavyweight object that should be created once per process.
+	c, err := client.NewClient(client.Options{
+		HostPort: client.DefaultHostPort,
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	wakeUpTime := time.Now().Add(20 * time.Second)
+
+	err = c.SignalWorkflow(context.Background(), updatabletimer.WorkflowID, "", updatabletimer.SignalType, wakeUpTime)
+	if err != nil {
+		log.Fatalln("Unable to signale workflow", err)
+	}
+	log.Println("Signaled workflow to update wake-up time",
+		"WorkflowID", updatabletimer.WorkflowID, "WakeUpTime", wakeUpTime)
+}

--- a/updatabletimer/worker/main.go
+++ b/updatabletimer/worker/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"log"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+
+	"github.com/temporalio/samples-go/timer"
+)
+
+func main() {
+	// The client and worker are heavyweight objects that should be created once per process.
+	c, err := client.NewClient(client.Options{
+		HostPort: client.DefaultHostPort,
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	w := worker.New(c, "timer", worker.Options{
+		MaxConcurrentActivityExecutionSize: 3,
+	})
+
+	w.RegisterWorkflow(timer.SampleTimerWorkflow)
+	w.RegisterActivity(timer.OrderProcessingActivity)
+	w.RegisterActivity(timer.SendEmailActivity)
+
+	err = w.Run(worker.InterruptCh())
+	if err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+}

--- a/updatabletimer/worker/main.go
+++ b/updatabletimer/worker/main.go
@@ -1,12 +1,11 @@
 package main
 
 import (
+	"github.com/temporalio/samples-go/updatabletimer"
 	"log"
 
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
-
-	"github.com/temporalio/samples-go/timer"
 )
 
 func main() {
@@ -19,13 +18,9 @@ func main() {
 	}
 	defer c.Close()
 
-	w := worker.New(c, "timer", worker.Options{
-		MaxConcurrentActivityExecutionSize: 3,
-	})
+	w := worker.New(c, updatabletimer.TaskQueue, worker.Options{})
 
-	w.RegisterWorkflow(timer.SampleTimerWorkflow)
-	w.RegisterActivity(timer.OrderProcessingActivity)
-	w.RegisterActivity(timer.SendEmailActivity)
+	w.RegisterWorkflow(updatabletimer.Workflow)
 
 	err = w.Run(worker.InterruptCh())
 	if err != nil {

--- a/updatabletimer/workflow.go
+++ b/updatabletimer/workflow.go
@@ -1,0 +1,63 @@
+package updatabletimer
+
+import (
+	"time"
+
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	QueryType  = "GetWakeUpTime"
+	SignalType = "UpdateWakeUpTime"
+)
+
+// UpdatableTimer is an example of a timer that can have its wake time updated
+type UpdatableTimer struct {
+	wakeUpTime time.Time
+}
+
+// SleepUntil sleeps until the provided wake-up time.
+// The wake-up time can be updated at any time by sending a new time over updateWakeUpTimeCh.
+// Supports ctx cancellation.
+// Returns temporal.CanceledError if ctx was canceled.
+func (u *UpdatableTimer) SleepUntil(ctx workflow.Context, wakeUpTime time.Time, updateWakeUpTimeCh workflow.ReceiveChannel) (err error) {
+	u.wakeUpTime = wakeUpTime
+	timerFired := false
+	for !timerFired && ctx.Err() == nil {
+		ctx, timerCancel := workflow.WithCancel(ctx)
+		duration := u.wakeUpTime.Sub(workflow.Now(ctx))
+		workflow.NewSelector(ctx).
+			AddFuture(workflow.NewTimer(ctx, duration), func(f workflow.Future) {
+				err := f.Get(ctx, nil)
+				// if a timer returned an error then it was canceled
+				if err == nil {
+					timerFired = true
+				}
+			}).
+			AddReceive(updateWakeUpTimeCh, func(c workflow.ReceiveChannel, more bool) {
+				timerCancel()                 // cancel outstanding timer
+				c.Receive(ctx, &u.wakeUpTime) // update wake-up time
+			}).
+			Select(ctx)
+	}
+	return ctx.Err()
+}
+
+func (u *UpdatableTimer) GetWakeUpTime() time.Time {
+	return u.wakeUpTime
+}
+
+// Workflow that sleeps initialWakeUpTime unless the new wake-up time is received through "UpdateWakeUpTime" signal.
+func Workflow(ctx workflow.Context, initialWakeUpTime time.Time) error {
+	workflow.GetLogger(ctx).Info("Start Workflow")
+	timer := UpdatableTimer{}
+	err := workflow.SetQueryHandler(ctx, QueryType, func() (time.Time, error) {
+		return timer.GetWakeUpTime(), nil
+	})
+	if err != nil {
+		return err
+	}
+	workflow.GetLogger(ctx).Info("Query Handler registered", QueryType)
+
+	return timer.SleepUntil(ctx, initialWakeUpTime, workflow.GetSignalChannel(ctx, SignalType))
+}

--- a/updatabletimer/workflow_test.go
+++ b/updatabletimer/workflow_test.go
@@ -27,7 +27,7 @@ func (s *UnitTestSuite) Test_Sleep() {
 		var queryResult time.Time
 		err = value.Get(&queryResult)
 		s.NoError(err)
-		s.Equal(wakeUpTime, queryResult)
+		s.True(wakeUpTime.Equal(queryResult))
 	}, time.Minute*10)
 	env.ExecuteWorkflow(Workflow, wakeUpTime)
 
@@ -54,7 +54,7 @@ func (s *UnitTestSuite) Test_UpdateWakeUpTime() {
 		var queryResult time.Time
 		err = value.Get(&queryResult)
 		s.NoError(err)
-		s.Equal(updatedWakeUpTime1, queryResult)
+		s.True(updatedWakeUpTime1.Equal(queryResult))
 	}, time.Minute*11)
 
 	// Update wake-up time again

--- a/updatabletimer/workflow_test.go
+++ b/updatabletimer/workflow_test.go
@@ -1,0 +1,76 @@
+package updatabletimer
+
+import (
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/testsuite"
+	"testing"
+	"time"
+)
+
+type UnitTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+}
+
+func TestUnitTestSuite(t *testing.T) {
+	suite.Run(t, new(UnitTestSuite))
+}
+
+func (s *UnitTestSuite) Test_Workflow() {
+	env := s.NewTestWorkflowEnvironment()
+	start := env.Now()
+	wakeUpTime := env.Now().Add(30 * time.Minute)
+	env.RegisterDelayedCallback(func() {
+		value, err := env.QueryWorkflow(QueryType)
+		s.NoError(err)
+		var queryResult time.Time
+		err = value.Get(&queryResult)
+		s.NoError(err)
+		s.Equal(wakeUpTime, queryResult)
+	}, time.Minute*10)
+	env.ExecuteWorkflow(Workflow, wakeUpTime)
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	elapsed := env.Now().Sub(start)
+	s.True(elapsed >= 30 * time.Minute)
+	s.True(elapsed < 31 * time.Minute)
+}
+
+func (s *UnitTestSuite) Test_Workflow_UpdateWakeUpTime() {
+	env := s.NewTestWorkflowEnvironment()
+	start := env.Now()
+	updatedWakeUpTime := env.Now().Add(15 * time.Minute)
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(SignalType, updatedWakeUpTime)
+	}, time.Minute*10)
+	wakeUpTime := env.Now().Add(30 * time.Minute)
+	env.ExecuteWorkflow(Workflow, wakeUpTime)
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	elapsed := env.Now().Sub(start).Milliseconds()
+	s.True(elapsed >= 15*60000)
+	s.True(elapsed < 16*60000)
+}
+
+//func (s *UnitTestSuite) Test_Workflow_SlowProcessing() {
+//	env := s.NewTestWorkflowEnvironment()
+//
+//	wg := &sync.WaitGroup{}
+//	wg.Add(1)
+//	env.OnActivity(OrderProcessingActivity, mock.Anything).Return(func(ctx context.Context) error {
+//		// simulate slow processing, will complete this activity only after the SendEmailActivity is called.
+//		wg.Wait()
+//		return nil
+//	})
+//	env.OnActivity(SendEmailActivity, mock.Anything).Return(func(ctx context.Context) error {
+//		wg.Done()
+//		return nil
+//	})
+//
+//	env.ExecuteWorkflow(Workflow, time.Microsecond)
+//
+//	s.True(env.IsWorkflowCompleted())
+//	s.NoError(env.GetWorkflowError())
+//}

--- a/updatabletimer/workflow_test.go
+++ b/updatabletimer/workflow_test.go
@@ -1,6 +1,7 @@
 package updatabletimer
 
 import (
+	"errors"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/sdk/testsuite"
 	"testing"
@@ -16,7 +17,7 @@ func TestUnitTestSuite(t *testing.T) {
 	suite.Run(t, new(UnitTestSuite))
 }
 
-func (s *UnitTestSuite) Test_Workflow() {
+func (s *UnitTestSuite) Test_Sleep() {
 	env := s.NewTestWorkflowEnvironment()
 	start := env.Now()
 	wakeUpTime := env.Now().Add(30 * time.Minute)
@@ -33,44 +34,58 @@ func (s *UnitTestSuite) Test_Workflow() {
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
 	elapsed := env.Now().Sub(start)
-	s.True(elapsed >= 30 * time.Minute)
-	s.True(elapsed < 31 * time.Minute)
+	s.Equal(elapsed, 30*time.Minute)
 }
 
-func (s *UnitTestSuite) Test_Workflow_UpdateWakeUpTime() {
+func (s *UnitTestSuite) Test_UpdateWakeUpTime() {
 	env := s.NewTestWorkflowEnvironment()
 	start := env.Now()
-	updatedWakeUpTime := env.Now().Add(15 * time.Minute)
+
+	// Update wake-up time
+	updatedWakeUpTime1 := env.Now().Add(15 * time.Minute)
 	env.RegisterDelayedCallback(func() {
-		env.SignalWorkflow(SignalType, updatedWakeUpTime)
+		env.SignalWorkflow(SignalType, updatedWakeUpTime1)
 	}, time.Minute*10)
+
+	// Check that it was updated
+	env.RegisterDelayedCallback(func() {
+		value, err := env.QueryWorkflow(QueryType)
+		s.NoError(err)
+		var queryResult time.Time
+		err = value.Get(&queryResult)
+		s.NoError(err)
+		s.Equal(updatedWakeUpTime1, queryResult)
+	}, time.Minute*11)
+
+	// Update wake-up time again
+	updatedWakeUpTime2 := env.Now().Add(40 * time.Minute)
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(SignalType, updatedWakeUpTime2)
+	}, time.Minute*12)
+
 	wakeUpTime := env.Now().Add(30 * time.Minute)
 	env.ExecuteWorkflow(Workflow, wakeUpTime)
 
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
-	elapsed := env.Now().Sub(start).Milliseconds()
-	s.True(elapsed >= 15*60000)
-	s.True(elapsed < 16*60000)
+	elapsed := env.Now().Sub(start)
+	// Check that the wake-up time was updated
+	s.Equal(elapsed, 40*time.Minute)
 }
 
-//func (s *UnitTestSuite) Test_Workflow_SlowProcessing() {
-//	env := s.NewTestWorkflowEnvironment()
-//
-//	wg := &sync.WaitGroup{}
-//	wg.Add(1)
-//	env.OnActivity(OrderProcessingActivity, mock.Anything).Return(func(ctx context.Context) error {
-//		// simulate slow processing, will complete this activity only after the SendEmailActivity is called.
-//		wg.Wait()
-//		return nil
-//	})
-//	env.OnActivity(SendEmailActivity, mock.Anything).Return(func(ctx context.Context) error {
-//		wg.Done()
-//		return nil
-//	})
-//
-//	env.ExecuteWorkflow(Workflow, time.Microsecond)
-//
-//	s.True(env.IsWorkflowCompleted())
-//	s.NoError(env.GetWorkflowError())
-//}
+func (s *UnitTestSuite) Test_CancelSleep() {
+	env := s.NewTestWorkflowEnvironment()
+	start := env.Now()
+	wakeUpTime := env.Now().Add(30 * time.Minute)
+	env.RegisterDelayedCallback(func() {
+		env.CancelWorkflow()
+	}, time.Minute*10)
+	env.ExecuteWorkflow(Workflow, wakeUpTime)
+
+	s.True(env.IsWorkflowCompleted())
+	workflowErr := env.GetWorkflowError()
+	s.Error(workflowErr)
+	s.EqualError(errors.Unwrap(workflowErr), "canceled")
+	elapsed := env.Now().Sub(start)
+	s.Equal(elapsed, 10*time.Minute)
+}


### PR DESCRIPTION
## What was changed
Added `updatabletimer` example.

## Why?
Java SDK has this example for a while. It implements a sleep function that can be rescheduled through an external signal at any time. It demonstrates use of Selector to wait on both a Channel and a Future simultaneously. It also demonstrates timer cancellation through a `workflow.Context` passed to the `workflow.NewTimer`.

2. How was this tested:
The sample includes a unit test. Its three executables were also tested manually.

3. Any docs updates needed?
The sample contains its own README. The root project README is also updated to include the new sample.