### PR TITLE
Fix encrypted-payloads data converter behaviour for local activity results

### DIFF
--- a/encrypted-payloads/crypt-converter.go
+++ b/encrypted-payloads/crypt-converter.go
@@ -12,6 +12,11 @@ import (
 	"go.temporal.io/sdk/converter"
 )
 
+const (
+	// MetadataEncodingEncrypted is "binary/encrypted"
+	MetadataEncodingEncrypted = "binary/encrypted"
+)
+
 // CryptDataConverter implements DataConverter using AES Crypt.
 type CryptDataConverter struct {
 	dataConverter converter.DataConverter
@@ -49,6 +54,38 @@ func encrypt(plaintext []byte, key []byte) ([]byte, error) {
 	return gcm.Seal(nonce, nonce, plaintext, nil), nil
 }
 
+func (dc *CryptDataConverter) encryptPayload(payload *commonpb.Payload, key []byte) (*commonpb.Payload, error) {
+	serializedPayload, err := payload.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", converter.ErrUnableToEncode, err)
+	}
+
+	encryptedPayload, err := encrypt(serializedPayload, key)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", converter.ErrUnableToEncode, err)
+	}
+
+	return &commonpb.Payload{
+		Metadata: map[string][]byte{
+			converter.MetadataEncoding: []byte(MetadataEncodingEncrypted),
+		},
+		Data: encryptedPayload,
+	}, nil
+}
+
+func isEncryptedPayload(payload *commonpb.Payload) bool {
+	metadata := payload.GetMetadata()
+	if metadata == nil {
+		return false
+	}
+
+	if encoding, ok := metadata[converter.MetadataEncoding]; ok {
+		return string(encoding) == MetadataEncodingEncrypted
+	}
+
+	return false
+}
+
 func decrypt(ciphertext []byte, key []byte) ([]byte, error) {
 	c, err := aes.NewCipher(key)
 	if err != nil {
@@ -69,9 +106,24 @@ func decrypt(ciphertext []byte, key []byte) ([]byte, error) {
 	return gcm.Open(nil, nonce, ciphertext, nil)
 }
 
+func (dc *CryptDataConverter) decryptPayload(payload *commonpb.Payload) (*commonpb.Payload, error) {
+	serializedPayload, err := decrypt(payload.GetData(), dc.getKey())
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", converter.ErrUnableToDecode, err)
+	}
+
+	result := &commonpb.Payload{}
+	err = result.Unmarshal(serializedPayload)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", converter.ErrUnableToDecode, err)
+	}
+
+	return result, nil
+}
+
 // ToPayloads converts a list of values.
 func (dc *CryptDataConverter) ToPayloads(values ...interface{}) (*commonpb.Payloads, error) {
-	result := &commonpb.Payloads{}
+	payloads := &commonpb.Payloads{}
 
 	for i, value := range values {
 		payload, err := dc.ToPayload(value)
@@ -79,35 +131,39 @@ func (dc *CryptDataConverter) ToPayloads(values ...interface{}) (*commonpb.Paylo
 			return nil, fmt.Errorf("values[%d]: %w", i, err)
 		}
 
-		result.Payloads = append(result.Payloads, payload)
+		encryptedPayload, err := dc.encryptPayload(payload, dc.getKey())
+		if err != nil {
+			return nil, fmt.Errorf("values[%d]: %w", i, err)
+		}
+
+		payloads.Payloads = append(payloads.Payloads, encryptedPayload)
 	}
 
-	return result, nil
+	return payloads, nil
 }
 
 // ToPayload converts single value to payload.
 func (dc *CryptDataConverter) ToPayload(value interface{}) (*commonpb.Payload, error) {
-	payload, err := dc.dataConverter.ToPayload(value)
-	if err != nil {
-		return nil, err
-	}
-
-	if payload != nil {
-		cryptData, err := encrypt(payload.GetData(), dc.getKey())
-		if err != nil {
-			return nil, fmt.Errorf("%w: %v", converter.ErrUnableToEncode, err)
-		}
-
-		payload.Data = cryptData
-	}
-
-	return payload, nil
+	return dc.dataConverter.ToPayload(value)
 }
 
 // FromPayloads converts to a list of values of different types.
 func (dc *CryptDataConverter) FromPayloads(payloads *commonpb.Payloads, valuePtrs ...interface{}) error {
 	for i, payload := range payloads.GetPayloads() {
-		err := dc.FromPayload(payload, valuePtrs[i])
+		if i >= len(valuePtrs) {
+			break
+		}
+
+		var err error
+
+		if isEncryptedPayload(payload) {
+			payload, err = dc.decryptPayload(payload)
+			if err != nil {
+				return fmt.Errorf("args[%d]: %w", i, err)
+			}
+		}
+
+		err = dc.dataConverter.FromPayload(payload, valuePtrs[i])
 		if err != nil {
 			return fmt.Errorf("args[%d]: %w", i, err)
 		}
@@ -118,13 +174,6 @@ func (dc *CryptDataConverter) FromPayloads(payloads *commonpb.Payloads, valuePtr
 
 // FromPayload converts single value from payload.
 func (dc *CryptDataConverter) FromPayload(payload *commonpb.Payload, valuePtr interface{}) error {
-	decryptData, err := decrypt(payload.GetData(), dc.getKey())
-	if err != nil {
-		return fmt.Errorf("%w: %v", converter.ErrUnableToDecode, err)
-	}
-
-	payload.Data = decryptData
-
 	return dc.dataConverter.FromPayload(payload, valuePtr)
 }
 
@@ -140,11 +189,14 @@ func (dc *CryptDataConverter) ToStrings(payloads *commonpb.Payloads) []string {
 
 // ToString converts payload object into human readable string.
 func (dc *CryptDataConverter) ToString(payload *commonpb.Payload) string {
-	decryptData, err := decrypt(payload.GetData(), dc.getKey())
-	// No way to return an error here...
-	if err == nil {
-		payload.Data = decryptData
+	if !isEncryptedPayload(payload) {
+		return dc.dataConverter.ToString(payload)
 	}
 
-	return dc.dataConverter.ToString(payload)
+	decryptedPayload, err := dc.decryptPayload(payload)
+	if err != nil {
+		return err.Error()
+	}
+
+	return dc.dataConverter.ToString(decryptedPayload)
 }

--- a/encrypted-payloads/encrypted-data_test.go
+++ b/encrypted-payloads/encrypted-data_test.go
@@ -32,16 +32,16 @@ func Test_DataConverter(t *testing.T) {
 		converter.GetDefaultDataConverter(),
 	)
 
-	defaultPayload, err := defaultDc.ToPayload("Testing")
+	defaultPayloads, err := defaultDc.ToPayloads("Testing")
 	require.NoError(t, err)
 
-	encryptedPayload, err := cryptDc.ToPayload("Testing")
+	encryptedPayloads, err := cryptDc.ToPayloads("Testing")
 	require.NoError(t, err)
 
-	require.NotEqual(t, defaultPayload.GetData(), encryptedPayload.GetData())
+	require.NotEqual(t, defaultPayloads.Payloads[0].GetData(), encryptedPayloads.Payloads[0].GetData())
 
 	var result string
-	err = cryptDc.FromPayload(encryptedPayload, &result)
+	err = cryptDc.FromPayloads(encryptedPayloads, &result)
 	require.NoError(t, err)
 
 	require.Equal(t, "Testing", result)


### PR DESCRIPTION
Fixes a bug which caused local activity results to not be encrypted in the history.

Also avoids trying to decrypt a payload that hasn't been encrypted.
