### PR TITLE
Interceptor Sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ Each sample demonstrates one feature of the SDK, together with tests.
 - [**Updatable Timer**](https://github.com/temporalio/samples-go/tree/master/updatabletimer): Demonstrates timer cancellation and use of a Selector to wait on a Future and a Channel simultaneously.
 
 - [**Greetings**](https://github.com/temporalio/samples-go/tree/master/greetings): Demonstrates how to pass dependencies to activities defined as struct methods.
--
+
 - [**Greetings Local**](https://github.com/temporalio/samples-go/tree/master/greetingslocal): Demonstrates how to pass dependencies to local activities defined as struct methods.
+
+- [**Interceptors**](https://github.com/temporalio/samples-go/tree/master/interceptor): Demonstrates how to use interceptors to intercept calls, in this case for adding context to the logger.
 
 ### Dynamic Workflow logic examples
 

--- a/interceptor/README.md
+++ b/interceptor/README.md
@@ -1,0 +1,17 @@
+# Interceptor Sample
+
+This sample shows how to make a worker interceptor that intercepts workflow and activity `GetLogger` calls to customize
+the logger.
+
+### Steps to run this sample:
+1) You need a Temporal service running. See details in README.md
+2) Run the following command to start the worker
+```
+go run ./interceptor/worker
+```
+3) Run the following command to start the example
+```
+go run ./interceptor/starter
+```
+
+Notice the log output has the `my-custom-key` tag with the `my-custom-value` value.

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -1,0 +1,94 @@
+package interceptor
+
+import (
+	"context"
+
+	"go.temporal.io/sdk/interceptor"
+	"go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/workflow"
+)
+
+type workerInterceptor struct {
+	interceptor.WorkerInterceptorBase
+	customLogTags []interface{}
+}
+
+type InterceptorOptions struct {
+	CustomLogTags map[string]interface{}
+}
+
+func NewWorkerInterceptor(options InterceptorOptions) interceptor.WorkerInterceptor {
+	// Convert map to slice
+	tags := make([]interface{}, 0, len(options.CustomLogTags)*2)
+	for k, v := range options.CustomLogTags {
+		tags = append(tags, k, v)
+	}
+	return &workerInterceptor{customLogTags: tags}
+}
+
+func (w *workerInterceptor) withCustomLogTags(logger log.Logger) log.Logger {
+	if len(w.customLogTags) > 0 {
+		return log.With(logger, w.customLogTags...)
+	}
+	return logger
+}
+
+func (w *workerInterceptor) InterceptActivity(
+	ctx context.Context,
+	next interceptor.ActivityInboundInterceptor,
+) interceptor.ActivityInboundInterceptor {
+	i := &activityInboundInterceptor{root: w}
+	i.Next = next
+	return i
+}
+
+type activityInboundInterceptor struct {
+	interceptor.ActivityInboundInterceptorBase
+	root *workerInterceptor
+}
+
+func (a *activityInboundInterceptor) Init(outbound interceptor.ActivityOutboundInterceptor) error {
+	i := &activityOutboundInterceptor{root: a.root}
+	i.Next = outbound
+	return a.Next.Init(i)
+}
+
+type activityOutboundInterceptor struct {
+	interceptor.ActivityOutboundInterceptorBase
+	root *workerInterceptor
+}
+
+func (a *activityOutboundInterceptor) GetLogger(ctx context.Context) log.Logger {
+	// Set our custom tags
+	return a.root.withCustomLogTags(a.Next.GetLogger(ctx))
+}
+
+func (w *workerInterceptor) InterceptWorkflow(
+	ctx workflow.Context,
+	next interceptor.WorkflowInboundInterceptor,
+) interceptor.WorkflowInboundInterceptor {
+	i := &workflowInboundInterceptor{root: w}
+	i.Next = next
+	return i
+}
+
+type workflowInboundInterceptor struct {
+	interceptor.WorkflowInboundInterceptorBase
+	root *workerInterceptor
+}
+
+func (w *workflowInboundInterceptor) Init(outbound interceptor.WorkflowOutboundInterceptor) error {
+	i := &workflowOutboundInterceptor{root: w.root}
+	i.Next = outbound
+	return w.Next.Init(i)
+}
+
+type workflowOutboundInterceptor struct {
+	interceptor.WorkflowOutboundInterceptorBase
+	root *workerInterceptor
+}
+
+func (w *workflowOutboundInterceptor) GetLogger(ctx workflow.Context) log.Logger {
+	// Set our custom tags
+	return w.root.withCustomLogTags(w.Next.GetLogger(ctx))
+}

--- a/interceptor/starter/main.go
+++ b/interceptor/starter/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/temporalio/samples-go/interceptor"
+	"go.temporal.io/sdk/client"
+)
+
+func main() {
+	// The client is a heavyweight object that should be created once per process.
+	c, err := client.NewClient(client.Options{})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	workflowOptions := client.StartWorkflowOptions{
+		ID:        "interceptor_workflowID",
+		TaskQueue: "interceptor",
+	}
+
+	we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, interceptor.Workflow, "Temporal")
+	if err != nil {
+		log.Fatalln("Unable to execute workflow", err)
+	}
+
+	log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
+
+	// Synchronously wait for the workflow completion.
+	var result string
+	err = we.Get(context.Background(), &result)
+	if err != nil {
+		log.Fatalln("Unable get workflow result", err)
+	}
+	log.Println("Workflow result:", result)
+}

--- a/interceptor/worker/main.go
+++ b/interceptor/worker/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"log"
+
+	"github.com/temporalio/samples-go/interceptor"
+	"go.temporal.io/sdk/client"
+	sdkinterceptor "go.temporal.io/sdk/interceptor"
+	"go.temporal.io/sdk/worker"
+)
+
+func main() {
+	// The client and worker are heavyweight objects that should be created once per process.
+	c, err := client.NewClient(client.Options{})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	w := worker.New(c, "interceptor", worker.Options{
+		// Create interceptor that will put our tag on the logger
+		Interceptors: []sdkinterceptor.WorkerInterceptor{interceptor.NewWorkerInterceptor(interceptor.InterceptorOptions{
+			CustomLogTags: map[string]interface{}{"my-custom-key": "my-custom-value"},
+		})},
+	})
+
+	w.RegisterWorkflow(interceptor.Workflow)
+	w.RegisterActivity(interceptor.Activity)
+
+	err = w.Run(worker.InterruptCh())
+	if err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+}

--- a/interceptor/workflow.go
+++ b/interceptor/workflow.go
@@ -1,0 +1,36 @@
+package interceptor
+
+import (
+	"context"
+	"time"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/workflow"
+)
+
+func Workflow(ctx workflow.Context, name string) (string, error) {
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: 10 * time.Second,
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	logger := workflow.GetLogger(ctx)
+	logger.Info("HelloWorld workflow started", "name", name)
+
+	var result string
+	err := workflow.ExecuteActivity(ctx, Activity, name).Get(ctx, &result)
+	if err != nil {
+		logger.Error("Activity failed.", "Error", err)
+		return "", err
+	}
+
+	logger.Info("HelloWorld workflow completed", "result", result)
+
+	return result, nil
+}
+
+func Activity(ctx context.Context, name string) (string, error) {
+	logger := activity.GetLogger(ctx)
+	logger.Info("Activity", "name", name)
+	return "Hello " + name + "!", nil
+}

--- a/interceptor/workflow_test.go
+++ b/interceptor/workflow_test.go
@@ -1,0 +1,85 @@
+package interceptor_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/samples-go/interceptor"
+	sdkinterceptor "go.temporal.io/sdk/interceptor"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
+)
+
+func TestWorkflow(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	// Set our capturing logger
+	var capturingLogger capturingLogger
+	suite.SetLogger(&capturingLogger)
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterActivity(interceptor.Activity)
+
+	// Add our interceptor to put a custom tag on the logs
+	env.SetWorkerOptions(worker.Options{
+		Interceptors: []sdkinterceptor.WorkerInterceptor{interceptor.NewWorkerInterceptor(interceptor.InterceptorOptions{
+			CustomLogTags: map[string]interface{}{"my-custom-key": "my-custom-value"},
+		})},
+	})
+
+	// Run workflow
+	env.ExecuteWorkflow(interceptor.Workflow, "Temporal")
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	var result string
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.Equal(t, "Hello Temporal!", result)
+
+	// Confirm logs
+	require.True(t, capturingLogger.hasEntry("INFO", "HelloWorld workflow started", "my-custom-key", "my-custom-value"))
+	require.True(t, capturingLogger.hasEntry("INFO", "Activity", "my-custom-key", "my-custom-value"))
+}
+
+type capturingLogger struct {
+	entries []*logEntry
+}
+
+type logEntry struct {
+	level string
+	msg   string
+	tags  []interface{}
+}
+
+func (c *capturingLogger) addEntry(level, msg string, tags []interface{}) {
+	c.entries = append(c.entries, &logEntry{level, msg, tags})
+}
+
+func (c *capturingLogger) Debug(msg string, tags ...interface{}) { c.addEntry("DEBUG", msg, tags) }
+func (c *capturingLogger) Info(msg string, tags ...interface{})  { c.addEntry("INFO", msg, tags) }
+func (c *capturingLogger) Warn(msg string, tags ...interface{})  { c.addEntry("WARN", msg, tags) }
+func (c *capturingLogger) Error(msg string, tags ...interface{}) { c.addEntry("ERROR", msg, tags) }
+
+func (c *capturingLogger) hasEntry(level, msg string, atLeastTags ...interface{}) bool {
+	for _, entry := range c.entries {
+		if entry.level == level && entry.msg == msg {
+			allTagsFound := true
+			for i := 0; i < len(atLeastTags); i += 2 {
+				if i+1 >= len(atLeastTags) || !entry.hasTag(atLeastTags[i], atLeastTags[i+1]) {
+					allTagsFound = false
+					break
+				}
+			}
+			if allTagsFound {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (l *logEntry) hasTag(k, v interface{}) bool {
+	for i := 0; i < len(l.tags); i += 2 {
+		if l.tags[i] == k && i+1 < len(l.tags) && l.tags[i+1] == v {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What was changed

Added simple interceptor example to show how to affect `GetLogger` with custom tags.

## Why?

There was no example showing how to create and configure interceptors. This specific one shows how to go all the way to outbound.

## Checklist

1. Closes #150
2. Closes https://github.com/temporalio/sdk-go/pull/668