### PR TITLE
Include a side effect and a local activity.

### DIFF
--- a/codec-server/workflow.go
+++ b/codec-server/workflow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/google/uuid"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/workflow"
 )
@@ -15,13 +16,32 @@ func Workflow(ctx workflow.Context, input string) (string, error) {
 	ao := workflow.ActivityOptions{
 		StartToCloseTimeout: 10 * time.Second,
 	}
+	lao := workflow.LocalActivityOptions{
+		StartToCloseTimeout: 10 * time.Second,
+	}
 	ctx = workflow.WithActivityOptions(ctx, ao)
+	ctx = workflow.WithLocalActivityOptions(ctx, lao)
 
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Codec Server workflow started", "input", input)
 
 	var result string
-	err := workflow.ExecuteActivity(ctx, Activity, input).Get(ctx, &result)
+
+	err := workflow.SideEffect(ctx, func(ctx workflow.Context) interface{} {
+		return uuid.New()
+	}).Get(&result)
+	if err != nil {
+		logger.Error("SideEffect failed.", "Error", err)
+		return "", err
+	}
+
+	err = workflow.ExecuteLocalActivity(ctx, Activity, input).Get(ctx, &result)
+	if err != nil {
+		logger.Error("Local Activity failed.", "Error", err)
+		return "", err
+	}
+
+	err = workflow.ExecuteActivity(ctx, Activity, input).Get(ctx, &result)
 	if err != nil {
 		logger.Error("Activity failed.", "Error", err)
 		return "", err

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2 // indirect
 	github.com/golang/mock v1.6.0
 	github.com/golang/snappy v0.0.4
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pborman/uuid v1.2.1


### PR DESCRIPTION
## What was changed
Included a side effect and local activity in the code-server workflow.

## Why?

This is to show a more varied history, helpful when testing the codec support.

## Checklist

1. How was this tested:

Ran the sample steps. Checked that https://github.com/temporalio/web/pull/446 showed expects results.
