### PR TITLE
Simplify tctl auth instructions.

### DIFF
--- a/codec-server/README.md
+++ b/codec-server/README.md
@@ -1,10 +1,9 @@
 ### Steps to run this sample:
 
 This sample shows how to decode payloads that have been encoded by a codec so they can be displayed by tctl and Temporal Web.
-The codec server supports OIDC authentication (via JWT in the Authorization header).
-If you are using OIDC for Temporal Web this token can be passed on to the codec server, see:
-https://github.com/temporalio/web/pull/445/files#diff-2eea834a27d42e5223553feb6a5795a37d859e2845df9a5b6b938a8f0a8271c4R23
-Configuring OIDC is outside of the scope of this sample, but please see ../serverjwtauth for more details about authentication.
+The sample codec server supports OIDC authentication (via JWT in the Authorization header).
+Temporal Web can be configured to pass the user's OIDC access token to the codec server, see: https://github.com/temporalio/web#configuration
+Configuring OIDC is outside of the scope of this sample, but please see [../serverjwtauth](../serverjwtauth/) for more details about authentication.
 
 1) You need a Temporal service running. See details in README.md
 2) Run the following command to start the worker

--- a/serverjwtauth/README.md
+++ b/serverjwtauth/README.md
@@ -64,18 +64,16 @@ When starting the server using the docker container, the following excerpt will 
 This is because by default the docker container attempts to register the `default` namespace, but cannot because we have
 restricted access to the server to only authorized uses.
 
-To create this manually, we will use `tctl`. According to
-[the tctl docs](https://docs.temporal.io/docs/devtools/tctl/#securing-tctl) we can use the `tctl-authorization-plugin`
-binary. If using docker, this binary is included with tctl otherwise, build it and put it on the `PATH`.
+To create this manually, we will use `tctl`.
 
-We must set the `TEMPORAL_CLI_AUTHORIZATION_TOKEN` environment variable with an authorization header value that includes
+We must set the `TEMPORAL_CLI_AUTH` environment variable with an authorization header value that includes
 the JWT key. The following command generates a 1 hour key with `admin` permissions on the `system` namespace:
 
     go run ./serverjwtauth/key tctl-system-token
 
 This will output something like:
 
-    TEMPORAL_CLI_AUTHORIZATION_TOKEN=Bearer abcde...
+    TEMPORAL_CLI_AUTH=Bearer abcde...
 
 See [this documentation](https://docs.temporal.io/docs/devtools/tctl/#run-the-cli) on how to run `tctl` with environment
 variables. If using the docker approach from bash, an argument could be added like:
@@ -88,11 +86,7 @@ Or if using `tctl` standalone from bash, an `export` for the environment can be 
 
 Once `tctl` is set to take an environment variable, it can be run to create the `default` namespace:
 
-    tctl --headers_provider_plugin tctl-authorization-plugin --ns default namespace register -rd 1
-
-We pass `--headers_provider_plugin tctl-authorization-plugin` so the environment variable is used for authentication. A
-more advanced use case could very easily create a new plugin binary for the header provider in [keyutil.go](keyutil.go)
-but that is beyond the scope of this sample.
+    tctl --ns default namespace register -rd 1
 
 ### Running the worker and starting the workflow
 

--- a/serverjwtauth/key/main.go
+++ b/serverjwtauth/key/main.go
@@ -99,6 +99,6 @@ func tctlSystemToken() error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("TEMPORAL_CLI_AUTHORIZATION_TOKEN=Bearer %v", token)
+	fmt.Printf("TEMPORAL_CLI_AUTH=Bearer %v", token)
 	return nil
 }


### PR DESCRIPTION
## What was changed
Removed mention of the tctl auth plugin.

## Why?
https://github.com/temporalio/tctl/pull/166 adds a built-in way to set the Authorization header without needing a plugin.
