### PR TITLE
Small fix for recovery sample

### DIFF
--- a/recovery/starter/main.go
+++ b/recovery/starter/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"log"
+	"time"
 
 	"go.temporal.io/sdk/client"
 
@@ -49,6 +50,7 @@ func main() {
 		workflowOptions := client.StartWorkflowOptions{
 			ID:        workflowID,
 			TaskQueue: "recovery",
+			WorkflowExecutionTimeout: 1 * time.Minute,
 		}
 		we, weError = c.ExecuteWorkflow(context.Background(), workflowOptions, recovery.RecoverWorkflow, params)
 	default:


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

Sample was failing because was expecting a set WorkflowExecutionTimeout 
without it in recovery workflow:

expiration := info.WorkflowExecutionTimeout

expiration would be set to 0 which is an invalid value for StartToCloseTimeout causing workflow errors