### PR TITLE
Update to metrics sample

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -8,4 +8,5 @@ go run metrics/worker/main.go
 ```
 go run metrics/starter/main.go
 ```
-4) Check metrics at http://localhost:9090/metrics (this is where the Prometheus agent scrapes it from).
+4) Check metrics at http://localhost:9092/metrics
+You can set up Prometheus scrape point config to use this url

--- a/metrics/worker/main.go
+++ b/metrics/worker/main.go
@@ -18,7 +18,7 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		MetricsHandler: sdktally.NewMetricsHandler(newPrometheusScope(prometheus.Configuration{
-			ListenAddress: "0.0.0.0:9090",
+			ListenAddress: "0.0.0.0:9092",
 			TimerType:     "histogram",
 		})),
 	})
@@ -55,6 +55,8 @@ func newPrometheusScope(c prometheus.Configuration) tally.Scope {
 		Separator:       prometheus.DefaultSeparator,
 		SanitizeOptions: &sanitizeOptions,
 		Prefix:          "temporal_samples",
+		Tags:            map[string]string{"my_key1": "my_value1",
+			                       "my_key2": "my_value2"},
 	}
 	scope, _ := tally.NewRootScope(scopeOpts, time.Second)
 

--- a/metrics/workflow.go
+++ b/metrics/workflow.go
@@ -17,6 +17,9 @@ func Workflow(ctx workflow.Context) error {
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Metrics workflow started.")
 
+	// custom
+	workflow.GetMetricsHandler(ctx).Counter("my_workflow_counter").Inc(1)
+
 	scheduledTimeNanos := workflow.Now(ctx).UnixNano()
 	_ = workflow.Sleep(ctx, 500*time.Millisecond)
 	err := workflow.ExecuteActivity(ctx, Activity, scheduledTimeNanos).Get(ctx, nil)


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

* adds how to add custom metric in workflow code
* adds how to set custom tags
* updates worker to publish metrics on port 9092 (default server metrics are exposed on port 9090 so this way it wont clash).  