### PR TITLE
Use errors.Is instead of == for error comparison

### DIFF
--- a/reqrespquery/requester.go
+++ b/reqrespquery/requester.go
@@ -2,6 +2,7 @@ package reqrespquery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -69,7 +70,7 @@ func (r *Requester) RequestUppercase(ctx context.Context, str string) (string, e
 			var resp *Response
 			err = val.Get(&resp)
 			// We continue on ErrNoData
-			if err != nil && err != temporal.ErrNoData {
+			if err != nil && !errors.Is(err, temporal.ErrNoData) {
 				return "", fmt.Errorf("failed unmarshalling response: %w", err)
 			} else if resp != nil && resp.Error != "" {
 				return "", fmt.Errorf("request failed: %v", resp.Error)


### PR DESCRIPTION
This allows wrapped errors to be matched correctly.
<!--- For ALL Contributors 👇 -->

## What was changed

Changed an error check that was previously performed via `err != temporal.ErrNoData` to use `errors.Is` instead.
<!-- Describe what has changed in this PR -->

## Why?
Using `errors.Is` is the preferred way since Go 1.13. `!errors.Is(err, temporal.ErrNoData)` returns `false` even if `temporal.ErrNoData` is wrapped inside `err` (and not literally equal).
<!-- Tell your future self why have you made these changes -->

## Checklist
The change is so minor that it should be possible to just carefully check the diff.