### PR TITLE
Allow ability to load client options from config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,20 +5,21 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Launch file",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${file}",
+            "env": {
+                "TEMPORAL_ENVIRONMENT": ""
+            }
+        },
+        {
             "name": "Launch test package",
             "type": "go",
             "request": "launch",
             "mode": "test",
             "program": "${file}"//"${workspaceFolder}"
-        },
-        {
-            "name": "Launch worker",
-            "type": "go",
-            "request": "launch",
-            "mode": "debug",
-            "program": "${file}",
-            "cwd": "${workspaceFolder}",
-            "args": ["-m", "worker"]
         }
     ]
 }

--- a/common/config.go
+++ b/common/config.go
@@ -1,0 +1,18 @@
+package common
+
+type (
+	Temporal struct {
+		HostNameAndPort string `yaml:"host"`
+		Namespace       string `yaml:"namespace"`
+
+		CaFile   string `yaml:"caFile"`
+		CertFile string `yaml:"certFile"`
+		KeyFile  string `yaml:"keyFile"`
+
+		CaData   string `yaml:"caData"`
+		CertData string `yaml:"certData"`
+		KeyData  string `yaml:"keyData"`
+
+		EnableHostVerification bool `yaml:"enableHostVerification"`
+	}
+)

--- a/common/connectivity.go
+++ b/common/connectivity.go
@@ -1,0 +1,134 @@
+package common
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+
+	"go.temporal.io/sdk/client"
+)
+
+func GetClientOptions() client.Options {
+	configHome := getEnvOrDefaultString(EnvKeyConfigHome, EnvDefaultConfigHome)
+	configEnv := getEnvOrDefaultString(EnvKeyEnvironment, EnvDefaultEnvironment)
+
+	configRoot := filepath.Join(configHome, configEnv)
+	// Use Home Directory to contruct the configRoot if it is specified as relative path
+	if !filepath.IsAbs(configRoot) {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			panic(err)
+		}
+		configRoot = filepath.Join(homeDir, configRoot)
+	}
+
+	if _, err := os.Stat(configRoot); err != nil {
+		// Config root does not exist
+		// Use default options to initialize client
+		return client.Options{}
+	}
+
+	var cfg Temporal
+	if err := loadConfig(configRoot, &cfg); err != nil {
+		panic(err)
+	}
+
+	options := client.Options{
+		HostPort:  cfg.HostNameAndPort,
+		Namespace: cfg.Namespace,
+	}
+
+	tlsConfig, err := getTLSConfiguration(configRoot, cfg)
+	if err != nil {
+		panic(err)
+	}
+	if tlsConfig != nil {
+		options.ConnectionOptions = client.ConnectionOptions{
+			TLS: tlsConfig,
+		}
+	}
+
+	return options
+}
+
+func getTLSConfiguration(configRoot string, config Temporal) (*tls.Config, error) {
+	// Ignoring error as we'll fail to dial anyway, and that will produce a meaningful error
+	host, _, _ := net.SplitHostPort(config.HostNameAndPort)
+
+	caBytes, err := getCertificateData(configRoot, config.CaFile, config.CaData)
+	if err != nil {
+		return nil, err
+	}
+
+	clientCertBytes, err := getCertificateData(configRoot, config.CertFile, config.CertData)
+	if err != nil {
+		return nil, err
+	}
+
+	clientCertKeyBytes, err := getCertificateData(configRoot, config.KeyFile, config.KeyData)
+	if err != nil {
+		return nil, err
+	}
+
+	var cert *tls.Certificate
+	var caPool *x509.CertPool
+
+	if len(clientCertBytes) > 0 {
+		clientCert, err := tls.X509KeyPair(clientCertBytes, clientCertKeyBytes)
+		if err != nil {
+			return nil, err
+		}
+		cert = &clientCert
+	}
+
+	if len(caBytes) > 0 {
+		caPool = x509.NewCertPool()
+		if !caPool.AppendCertsFromPEM(caBytes) {
+			return nil, errors.New("unknown failure constructing cert pool for ca")
+		}
+	}
+
+	// If we are given arguments to verify either server or client, configure TLS
+	if caPool != nil || cert != nil {
+		tlsConfig := &tls.Config{
+			InsecureSkipVerify: !config.EnableHostVerification,
+			ServerName:         host,
+		}
+		if caPool != nil {
+			tlsConfig.RootCAs = caPool
+		}
+		if cert != nil {
+			tlsConfig.Certificates = []tls.Certificate{*cert}
+		}
+
+		return tlsConfig, nil
+	}
+
+	return nil, nil
+}
+
+func getCertificateData(
+	configRoot string,
+	fileSource string,
+	configSource string,
+) ([]byte, error) {
+	if fileSource != "" && configSource != "" {
+		return nil, fmt.Errorf("cannot supply both file path and base64-encoded value")
+	}
+
+	if configSource != "" {
+		return base64.StdEncoding.DecodeString(configSource)
+	}
+
+	if fileSource != "" {
+		return ioutil.ReadFile(filepath.Join(configRoot, fileSource))
+	}
+
+	return nil, nil
+}

--- a/common/loader.go
+++ b/common/loader.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/validator.v2"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	EnvKeyConfigHome  = "TEMPORAL_CONFIG_ROOT"
+	EnvKeyEnvironment = "TEMPORAL_ENVIRONMENT"
+	EnvKeyConfigFile  = "TEMPORAL_CONFIG_FILE"
+
+	EnvDefaultConfigHome  = ".temporal"
+	EnvDefaultEnvironment = "local"
+	EnvDefaultConfigFile  = "config.yaml"
+)
+
+func loadConfig(configRoot string, config interface{}) error {
+	configFile := getEnvOrDefaultString(EnvKeyConfigFile, EnvDefaultConfigFile)
+
+	configPath := filepath.Join(configRoot, configFile)
+	fmt.Printf("Loading config from: %v\n", configPath)
+
+	data, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(data, config)
+	if err != nil {
+		return err
+	}
+
+	return validator.Validate(config)
+}
+
+func getEnvOrDefaultString(envVarName string, defaultValue string) string {
+	value := strings.TrimSpace(os.Getenv(envVarName))
+	if value == "" {
+		value = defaultValue
+	}
+
+	return value
+}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	go.temporal.io/server v1.15.2
 	go.uber.org/zap v1.20.0
 	google.golang.org/grpc v1.47.0
-	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0
+	gopkg.in/validator.v2 v2.0.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -297,6 +297,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -965,6 +967,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
@@ -973,6 +977,8 @@ gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76
 gopkg.in/validator.v2 v2.0.0-20200605151824-2b28d334fa05/go.mod h1:o4V0GXN9/CAmCsvJ0oXYZvrZOe7syiDZSN1GWGZTGzc=
 gopkg.in/validator.v2 v2.0.0-20210331031555-b37d688a7fb0 h1:EFLtLCwd8tGN+r/ePz3cvRtdsfYNhDEdt/vp6qsT+0A=
 gopkg.in/validator.v2 v2.0.0-20210331031555-b37d688a7fb0/go.mod h1:o4V0GXN9/CAmCsvJ0oXYZvrZOe7syiDZSN1GWGZTGzc=
+gopkg.in/validator.v2 v2.0.1 h1:xF0KWyGWXm/LM2G1TrEjqOu4pa6coO9AlWSf3msVfDY=
+gopkg.in/validator.v2 v2.0.1/go.mod h1:lIUZBlB3Im4s/eYp39Ry/wkR02yOPhZ9IwIRBjuPuG8=
 gopkg.in/yaml.v2 v2.0.0-20160301204022-a83829b6f129/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/helloworld/starter/main.go
+++ b/helloworld/starter/main.go
@@ -6,12 +6,15 @@ import (
 
 	"go.temporal.io/sdk/client"
 
+	"github.com/temporalio/samples-go/common"
 	"github.com/temporalio/samples-go/helloworld"
 )
 
 func main() {
+	options := common.GetClientOptions()
+
 	// The client is a heavyweight object that should be created once per process.
-	c, err := client.Dial(client.Options{})
+	c, err := client.Dial(options)
 	if err != nil {
 		log.Fatalln("Unable to create client", err)
 	}

--- a/helloworld/worker/main.go
+++ b/helloworld/worker/main.go
@@ -6,12 +6,15 @@ import (
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
 
+	"github.com/temporalio/samples-go/common"
 	"github.com/temporalio/samples-go/helloworld"
 )
 
 func main() {
+	options := common.GetClientOptions()
+
 	// The client and worker are heavyweight objects that should be created once per process.
-	c, err := client.Dial(client.Options{})
+	c, err := client.Dial(options)
 	if err != nil {
 		log.Fatalln("Unable to create client", err)
 	}


### PR DESCRIPTION
## What was changed
- Added helper methods to load config for constructing client options
- Modified helloworld sample to use the newly added helper method

User can now control different configs through following environment variables
```
TEMPORAL_CONFIG_ROOT=".temporal"
TEMPORAL_ENVIRONMENT="local"
TEMPORAL_CONFIG_FILE  = "config.yaml"
```

Config File Format
```
host: "localhost:7233"
namespace: "default"
caFile: ""
certFile: ""
keyFile: ""
caData: ""
certData: ""
keyData: ""
```

## Why?
<!-- Tell your future self why have you made these changes -->
Allowing ability to easily load client options from config enables user to run
samples against any environment including Temporal Cloud

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Manually ran this against both local docker-compose setup and Temporal Cloud

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
