### PR TITLE
Add TLS related flags to helloworldmtls example

### DIFF
--- a/helloworldmtls/README.md
+++ b/helloworldmtls/README.md
@@ -8,3 +8,7 @@ go run ./helloworldmtls/worker -target-host my.namespace.tmprl.cloud:7233 -names
 ```
 go run ./helloworldmtls/starter -target-host my.namespace.tmprl.cloud:7233 -namespace my.namespace -client-cert path/to/cert.pem -client-key path/to/key.pem
 ```
+
+If the server uses self-signed certificates, pass one of the following two options when starting the worker or the example above:
+1. `-server-name` and provide the common name contained in the self-signed server certificate
+2. `-insecure-skip-verify` which disables certificate and host name validation

--- a/helloworldmtls/README.md
+++ b/helloworldmtls/README.md
@@ -9,6 +9,6 @@ go run ./helloworldmtls/worker -target-host my.namespace.tmprl.cloud:7233 -names
 go run ./helloworldmtls/starter -target-host my.namespace.tmprl.cloud:7233 -namespace my.namespace -client-cert path/to/cert.pem -client-key path/to/key.pem
 ```
 
-If the server uses self-signed certificates, pass one of the following two options when starting the worker or the example above:
+If the server uses self-signed certificates and does not have the SAN set to the actual host, pass one of the following two options when starting the worker or the example above:
 1. `-server-name` and provide the common name contained in the self-signed server certificate
 2. `-insecure-skip-verify` which disables certificate and host name validation

--- a/helloworldmtls/helloworld.go
+++ b/helloworldmtls/helloworld.go
@@ -53,6 +53,7 @@ func ParseClientOptionFlags(args []string) (client.Options, error) {
 	serverRootCACert := set.String("server-root-ca-cert", "", "Optional path to root server CA cert")
 	clientCert := set.String("client-cert", "", "Required path to client cert")
 	clientKey := set.String("client-key", "", "Required path to client key")
+	serverName := set.String("server-name", "", "Server name to use for verifying the server's certificate")
 	if err := set.Parse(args); err != nil {
 		return client.Options{}, fmt.Errorf("failed parsing args: %w", err)
 	} else if *clientCert == "" || *clientKey == "" {
@@ -84,6 +85,7 @@ func ParseClientOptionFlags(args []string) (client.Options, error) {
 			TLS: &tls.Config{
 				Certificates: []tls.Certificate{cert},
 				RootCAs:      serverCAPool,
+				ServerName:   *serverName,
 			},
 		},
 	}, nil

--- a/helloworldmtls/helloworld.go
+++ b/helloworldmtls/helloworld.go
@@ -54,6 +54,7 @@ func ParseClientOptionFlags(args []string) (client.Options, error) {
 	clientCert := set.String("client-cert", "", "Required path to client cert")
 	clientKey := set.String("client-key", "", "Required path to client key")
 	serverName := set.String("server-name", "", "Server name to use for verifying the server's certificate")
+	insecureSkipVerify := set.Bool("insecure-skip-verify", false, "Skip verification of the server's certificate and host name")
 	if err := set.Parse(args); err != nil {
 		return client.Options{}, fmt.Errorf("failed parsing args: %w", err)
 	} else if *clientCert == "" || *clientKey == "" {
@@ -83,9 +84,10 @@ func ParseClientOptionFlags(args []string) (client.Options, error) {
 		Namespace: *namespace,
 		ConnectionOptions: client.ConnectionOptions{
 			TLS: &tls.Config{
-				Certificates: []tls.Certificate{cert},
-				RootCAs:      serverCAPool,
-				ServerName:   *serverName,
+				Certificates:       []tls.Certificate{cert},
+				RootCAs:            serverCAPool,
+				ServerName:         *serverName,
+				InsecureSkipVerify: *insecureSkipVerify,
 			},
 		},
 	}, nil


### PR DESCRIPTION
## What was changed

I added two options to the `helloworldmtls` example to be used when testing a Temporal Cluster that's secured with mTLS.

## Why?
In order to use the `helloworldmtls` example to test a Temporal Cluster that is secured via mTLS and uses self-signed certificates, either a) the server name contained in the server's certificate has to be passed or b) TLS verification needs to be disabled. I added both options.

## Checklist
1. Added `-server-name` and `-insecure-skip-verify` options to the `helloworldmtls` example.
2. Documented the change in the example's `README.md` file.

3. How was this tested:
Manually against our test cluster using the new options.

4. Any docs updates needed?
The additional options are documented in the example's `README.md` file.