### PR TITLE
Sample to limit concurrent activities in parallel 

### DIFF
--- a/capped-concurrent-activities/README.md
+++ b/capped-concurrent-activities/README.md
@@ -1,0 +1,19 @@
+This sample workflow demonstrates how to execute multiple activities in parallel keeping them to a maximum per workflow.
+
+### Steps to run this sample:
+
+1. You need a Temporal service running. See details in README.md
+2. Run the following command to start the worker
+
+```
+go run capped-concurrent-activities/worker/main.go
+```
+
+3. Run the following command to start the example
+
+```
+go run capped-concurrent-activities/starter/main.go
+```
+
+./temporalite start --namespace default --ephemeral
+http://localhost:8233/namespaces/default/workflows?query=&search=basic

--- a/capped-concurrent-activities/README.md
+++ b/capped-concurrent-activities/README.md
@@ -15,5 +15,3 @@ go run capped-concurrent-activities/worker/main.go
 go run capped-concurrent-activities/starter/main.go
 ```
 
-./temporalite start --namespace default --ephemeral
-http://localhost:8233/namespaces/default/workflows?query=&search=basic

--- a/capped-concurrent-activities/README.md
+++ b/capped-concurrent-activities/README.md
@@ -1,4 +1,4 @@
-This sample workflow demonstrates how to execute multiple activities in parallel keeping them to a maximum per workflow.
+This sample workflow demonstrates how to execute multiple activities in parallel running just a maximum at the time per workflow.
 
 ### Steps to run this sample:
 

--- a/capped-concurrent-activities/capped_activities_workflow.go
+++ b/capped-concurrent-activities/capped_activities_workflow.go
@@ -1,0 +1,89 @@
+package capped_activities
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/workflow"
+)
+
+/**
+ * This sample workflow demonstrates how to execute multiple activities in parallel and merge their results using futures.
+ * The futures are awaited using Selector. It allows processing them as soon as they become ready. See `split-merge-future` sample
+ * to see how to process them without Selector in the order of activity invocation instead.
+ */
+
+// ChunkResult contains the activity result for this sample
+type ChunkResult struct {
+	NumberOfItemsInChunk int
+	SumInChunk           int
+}
+
+// CappedActivitiesWorkflow workflow definition
+func CappedActivitiesWorkflow(ctx workflow.Context, workerCount int) (result ChunkResult, err error) {
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Second,
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	selector := workflow.NewSelector(ctx)
+	var totalItemCount, totalSum int
+
+	batchSize := 30
+
+	runActivity := func(i int) {
+		// ExecuteActivity returns Future that doesn't need to be awaited immediately.
+		future := workflow.ExecuteActivity(ctx, ChunkProcessingActivity, i+1)
+		selector.AddFuture(future, func(f workflow.Future) {
+			var r ChunkResult
+			err1 := f.Get(ctx, &r)
+			if err1 != nil {
+				err = err1
+				return
+			}
+			totalItemCount += r.NumberOfItemsInChunk
+			totalSum += r.SumInChunk
+		})
+	}
+
+	// Start a batch of concurrent activities
+	for i := 0; i < batchSize; i++ {
+		runActivity(i)
+	}
+
+	// For the rest of the activities wait for one running
+	// before adding a new one, this will keep the maximum
+	// number of activities running in parallel to the size of the batch
+	for j := batchSize; j < workerCount; j++ {
+		// Each call to Select matches a single ready Future.
+		// Each Future is matched only once independently on the number of Select calls.
+		selector.Select(ctx)
+		runActivity(j)
+
+		if err != nil {
+			return ChunkResult{}, err
+		}
+	}
+
+	// Wait for the pending activities
+	for i := 0; i < batchSize; i++ {
+		selector.Select(ctx)
+	}
+
+	workflow.GetLogger(ctx).Info("Workflow completed.")
+
+	return ChunkResult{totalItemCount, totalSum}, nil
+}
+
+func ChunkProcessingActivity(ctx context.Context, chunkID int) (result ChunkResult, err error) {
+	// some fake processing logic here
+	numberOfItemsInChunk := chunkID
+	sumInChunk := chunkID * chunkID
+
+	time.Sleep(time.Duration(1+rand.Intn(3)) * time.Second)
+
+	activity.GetLogger(ctx).Info("Chunk processed", "chunkID", chunkID)
+	return ChunkResult{numberOfItemsInChunk, sumInChunk}, nil
+}

--- a/capped-concurrent-activities/capped_activities_workflow.go
+++ b/capped-concurrent-activities/capped_activities_workflow.go
@@ -21,6 +21,8 @@ type ChunkResult struct {
 	SumInChunk           int
 }
 
+const batchSize = 10 // maximum activities running concurrently
+
 // CappedActivitiesWorkflow workflow definition
 func CappedActivitiesWorkflow(ctx workflow.Context, workerCount int) (result ChunkResult, err error) {
 	ao := workflow.ActivityOptions{
@@ -30,8 +32,6 @@ func CappedActivitiesWorkflow(ctx workflow.Context, workerCount int) (result Chu
 
 	selector := workflow.NewSelector(ctx)
 	var totalItemCount, totalSum int
-
-	batchSize := 30
 
 	runActivity := func(i int) {
 		// ExecuteActivity returns Future that doesn't need to be awaited immediately.

--- a/capped-concurrent-activities/capped_activities_workflow_test.go
+++ b/capped-concurrent-activities/capped_activities_workflow_test.go
@@ -1,0 +1,40 @@
+package capped_activities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/testsuite"
+)
+
+type UnitTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+}
+
+func TestUnitTestSuite(t *testing.T) {
+	suite.Run(t, new(UnitTestSuite))
+}
+
+func (s *UnitTestSuite) Test_Workflow() {
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterActivity(ChunkProcessingActivity)
+
+	workerCount := 90
+	env.ExecuteWorkflow(CappedActivitiesWorkflow, workerCount)
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+
+	var result ChunkResult
+	_ = env.GetWorkflowResult(&result)
+
+	totalItem, totalSum := 0, 0
+	for i := 1; i <= workerCount; i++ {
+		totalItem += i
+		totalSum += i * i
+	}
+
+	s.Equal(totalItem, result.NumberOfItemsInChunk)
+	s.Equal(totalSum, result.SumInChunk)
+}

--- a/capped-concurrent-activities/capped_activities_workflow_test.go
+++ b/capped-concurrent-activities/capped_activities_workflow_test.go
@@ -20,7 +20,7 @@ func (s *UnitTestSuite) Test_Workflow() {
 	env := s.NewTestWorkflowEnvironment()
 	env.RegisterActivity(ChunkProcessingActivity)
 
-	workerCount := 90
+	workerCount := 30
 	env.ExecuteWorkflow(CappedActivitiesWorkflow, workerCount)
 
 	s.True(env.IsWorkflowCompleted())

--- a/capped-concurrent-activities/starter/main.go
+++ b/capped-concurrent-activities/starter/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	capped_activities "github.com/temporalio/samples-go/capped-concurrent-activities"
+	"log"
+
+	"github.com/pborman/uuid"
+	"go.temporal.io/sdk/client"
+)
+
+func main() {
+	// The client is a heavyweight object that should be created once per process.
+	c, err := client.Dial(client.Options{
+		HostPort: client.DefaultHostPort,
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	workflowOptions := client.StartWorkflowOptions{
+		ID:        "capped_activities_" + uuid.New(),
+		TaskQueue: "capped-activities",
+	}
+
+	we, err := c.ExecuteWorkflow(context.Background(), workflowOptions,
+		capped_activities.CappedActivitiesWorkflow, 90)
+	if err != nil {
+		log.Fatalln("Unable to execute workflow", err)
+	}
+	log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
+}

--- a/capped-concurrent-activities/starter/main.go
+++ b/capped-concurrent-activities/starter/main.go
@@ -25,7 +25,7 @@ func main() {
 	}
 
 	we, err := c.ExecuteWorkflow(context.Background(), workflowOptions,
-		capped_activities.CappedActivitiesWorkflow, 90)
+		capped_activities.CappedActivitiesWorkflow, 30)
 	if err != nil {
 		log.Fatalln("Unable to execute workflow", err)
 	}

--- a/capped-concurrent-activities/worker/main.go
+++ b/capped-concurrent-activities/worker/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	capped_activities "github.com/temporalio/samples-go/capped-concurrent-activities"
+	"log"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+)
+
+func main() {
+	// The client and worker are heavyweight objects that should be created once per process.
+	c, err := client.Dial(client.Options{
+		HostPort: client.DefaultHostPort,
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	w := worker.New(c, "capped-activities", worker.Options{})
+
+	w.RegisterWorkflow(capped_activities.CappedActivitiesWorkflow)
+	w.RegisterActivity(capped_activities.ChunkProcessingActivity)
+
+	err = w.Run(worker.InterruptCh())
+	if err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+}


### PR DESCRIPTION
## What was changed
Added a new sample to show how to run a limited number of concurrent activities per workflow.

## Why?
There may be scenarios where the work performed by a single activity in a workflow is requiring too much resources, in that case it would be helpful to have an example on how to limit the number of concurrent activities per workflow and not per worker.
A discussion on the similar use case was found on https://community.temporal.io/t/limit-concurrent-activities-in-parallel/2066 but not a solutions with sample is currently available in this repo.

## Checklist

1. Closes

2. How was this tested:
Manually, through the sample with a local temporalite.

3. Any docs updates needed?

