### PR TITLE
move to golangci-lint and address linting issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ############################# Main targets #############################
 # Run all checks, build, and test.
-install: clean staticcheck errcheck workflowcheck bins test
+install: clean lint workflowcheck bins test
 ########################################################################
 
 ##### Variables ######
@@ -27,20 +27,15 @@ test:
 	$(NEWLINE))
 	@! grep -q "^--- FAIL" test.log
 
-staticcheck:
-	@printf $(COLOR) "Run static check..."
-	@GO111MODULE=off go get -u honnef.co/go/tools/cmd/staticcheck
-	@staticcheck ./...
-
-errcheck:
-	@printf $(COLOR) "Run error check..."
-	@GO111MODULE=off go get -u github.com/kisielk/errcheck
-	@errcheck ./...
+lint:
+	@printf $(COLOR) "Run checks..."
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+	@golangci-lint run --disable-all -E errcheck -E staticcheck
 
 workflowcheck:
 	@printf $(COLOR) "Run workflow check..."
 	@go install go.temporal.io/sdk/contrib/tools/workflowcheck
-	@workflowcheck -show-pos ./...
+	@workflowcheck -config workflowcheck.config.yaml -show-pos ./...
 
 update-sdk:
 	go get -u go.temporal.io/api@master
@@ -49,5 +44,5 @@ update-sdk:
 
 clean:
 	rm -rf bin
-	
-ci-build: staticcheck errcheck workflowcheck bins test
+
+ci-build: lint workflowcheck bins test

--- a/dsl/starter/main.go
+++ b/dsl/starter/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 	"flag"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/pborman/uuid"
 	"go.temporal.io/sdk/client"
@@ -18,7 +18,7 @@ func main() {
 	flag.StringVar(&dslConfig, "dslConfig", "dsl/workflow1.yaml", "dslConfig specify the yaml file for the dsl workflow.")
 	flag.Parse()
 
-	data, err := ioutil.ReadFile(dslConfig)
+	data, err := os.ReadFile(dslConfig)
 	if err != nil {
 		log.Fatalln("failed to load dsl config file", err)
 	}

--- a/expense/activities.go
+++ b/expense/activities.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -20,8 +20,8 @@ func CreateExpenseActivity(ctx context.Context, expenseID string) error {
 	if err != nil {
 		return err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
-	_ = resp.Body.Close()
+	defer resp.Body.Close() // nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -57,8 +57,8 @@ func WaitForDecisionActivity(ctx context.Context, expenseID string) (string, err
 		logger.Info("waitForDecisionActivity failed to register callback.", "Error", err)
 		return "", err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
-	_ = resp.Body.Close()
+	defer resp.Body.Close() // nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -86,8 +86,8 @@ func PaymentActivity(ctx context.Context, expenseID string) error {
 	if err != nil {
 		return err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
-	_ = resp.Body.Close()
+	defer resp.Body.Close() // nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/fileprocessing/activities.go
+++ b/fileprocessing/activities.go
@@ -2,7 +2,6 @@ package fileprocessing
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -40,7 +39,7 @@ func (a *Activities) ProcessFileActivity(ctx context.Context, fileName string) (
 	defer func() { _ = os.Remove(fileName) }() // cleanup temp file
 
 	// read downloaded file
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	if err != nil {
 		logger.Error("processFileActivity failed to read file.", "FileName", fileName, "Error", err)
 		return "", err
@@ -84,7 +83,7 @@ func (b *BlobStore) downloadFile(fileID string) []byte {
 
 func (b *BlobStore) uploadFile(ctx context.Context, filename string) error {
 	// dummy uploader
-	_, err := ioutil.ReadFile(filename)
+	_, err := os.ReadFile(filename)
 	for i := 0; i < 5; i++ {
 		time.Sleep(1 * time.Second)
 		// Demonstrates that heartbeat accepts progress data.
@@ -110,7 +109,7 @@ func transcodeData(ctx context.Context, data []byte) []byte {
 }
 
 func saveToTmpFile(data []byte) (f *os.File, err error) {
-	tmpFile, err := ioutil.TempFile("", "temporal_sample")
+	tmpFile, err := os.CreateTemp("", "temporal_sample")
 	if err != nil {
 		return nil, err
 	}

--- a/workflowcheck.config.yaml
+++ b/workflowcheck.config.yaml
@@ -1,0 +1,6 @@
+decls:
+  print: false
+  fmt.Printf: false
+  fmt.Sprintf: false
+  fmt.Sprint: false
+  fmt.Errorf: false


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Previously, two separate checks "errcheck" and "staticcheck" were used. These are also part of "golangci-lint" [1] metalinter.

In addition, "golangci-lint" has a nolint directive [2], which at least "errcheck" did not seem to have.

At this point in time, "golangci-lint" bundles 72 linters [3] (of which this project uses two) - so additional check can easily be added. A configuration file was required to suppress false positives regarding determinism stemming from "print" and "fmt" functions.

As this project use "go 1.16" some safe linting suggestions have been applied (e.g. related to deprecation of https://pkg.go.dev/io/ioutil).

* [1] https://golangci-lint.run/
* [2] https://golangci-lint.run/usage/false-positives/#nolint-directive
* [3] https://golangci-lint.run/usage/linters/

## Why?

I wanted to use the [nolint directive](https://golangci-lint.run/usage/false-positives/#nolint-directive) of [golangci-lint](https://golangci-lint.run/) to selectively ignore checks, e.g. to ignore an error in `defer` when closing an HTTP response body.  

At the same time, it seemed to simplify the `Makefile` to use a single "metalinter" instead of two separate linters.

## Checklist

<!--- add/delete as needed --->

2. How was this tested:

Tested locally, via:

```
$ make
```

3. Any docs updates needed?

Not required.
