### PR TITLE
Tw 219 update links go samples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build-and-test:

--- a/.gitpod.readme.md
+++ b/.gitpod.readme.md
@@ -13,4 +13,4 @@ When you first launch, we will open 3 terminals:
 
 It takes ~1 minute for the Docker Compose cluster to start up, so we put in manual sleeps as we have not found a more reliable solution.
 
-Once you have it up and running (Temporal Web should show the first Workflow Execution), you can use our [Hello World Walkthrough tutorial](https://docs.temporal.io/docs/go/hello-world-tutorial) to orient you to the sample file structure.
+Once you have it up and running (Temporal Web should show the first Workflow Execution), you can use our [Hello World Walkthrough tutorial](https://learn.temporal.io/getting_started/go/hello_world_in_go) to orient you to the sample file structure.

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ workflowcheck:
 	@workflowcheck -show-pos ./...
 
 update-sdk:
-	go get -u go.temporal.io/api@master
-	go get -u go.temporal.io/sdk@master
+	go get -u go.temporal.io/api@main
+	go get -u go.temporal.io/sdk@main
 	go mod tidy
 
 clean:

--- a/README.md
+++ b/README.md
@@ -11,39 +11,38 @@ Server via the Temporal Go SDK.
 
 ## How to use
 
-- You can run this in the browser with
+- Run this in the browser with
   Gitpod: [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/temporalio/samples-go/)
-- Or you can run Temporal Server locally
-  using [VSCode Remote Containers](https://code.visualstudio.com/docs/remote/containers)
+- Or run Temporal Server locally with [VSCode Remote Containers](https://code.visualstudio.com/docs/remote/containers)
   . [![Open in Remote - Containers](https://img.shields.io/static/v1?label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/temporalio/samples-go)
 - Lastly, you can run Temporal Server locally on your own (follow
-  the [Quick install guide](https://docs.temporal.io/docs/server/quick-install)), then clone this repository
+  the [Quick install guide](https://docs.temporal.io/clusters/quick-install)), then clone this repository
 
-The [helloworld](helloworld/README.md) sample is a good place to start.
+The [helloworld](helloworld) sample is a good place to start.
 
 ## Samples directory
 
 Each sample demonstrates one feature of the SDK, together with tests.
 
-- [**Basic hello world**](https://github.com/temporalio/samples-go/tree/master/helloworld): Simple example of a Workflow
+- [**Basic hello world**](helloworld): Simple example of a Workflow
   Definition and an Activity Definition.
 
-- [**Basic mTLS hello world**](https://github.com/temporalio/samples-go/tree/master/helloworldmtls): Simple example of a
+- [**Basic mTLS hello world**](helloworldmtls): Simple example of a
   Workflow Definition and an Activity Definition using mTLS like Temporal Cloud.
 
 ### API demonstrations
 
 - **Async activity completion**: Example of
-  an [Expense reporting](https://github.com/temporalio/samples-go/tree/master/expense) Workflow that communicates with a
+  an [Expense reporting](expense) Workflow that communicates with a
   server API. Additional
-  documentation: [How to complete an Activity Execution asynchronously in Go](https://docs.temporal.io/docs/go/activities/#asynchronous-activity-completion)
+  documentation: [How to complete an Activity Execution asynchronously in Go](https://docs.temporal.io/application-development/foundations/#develop-activities)
 
-- [**Retry Activity Execution**](https://github.com/temporalio/samples-go/tree/master/retryactivity): This samples
+- [**Retry Activity Execution**](retryactivity): This samples
   executes an unreliable Activity. The Activity is executed with a custom Retry Policy. If the Activity Execution fails,
   the Server will schedule a retry based on the Retry Policy. This Activity also includes a Heartbeat, which enables it
   to resume from the Activity Execution's last reported progress when it retries.
 
-- [**Child Workflow**](https://github.com/temporalio/samples-go/tree/master/child-workflow): Demonstrates how to use
+- [**Child Workflow**](child-workflow): Demonstrates how to use
   execute a Child Workflow from a Parent Workflow Execution. A Child Workflow Execution only returns to the Parent
   Workflow Execution after completing its last Run.
 
@@ -54,41 +53,40 @@ Each sample demonstrates one feature of the SDK, together with tests.
   feature when there is a need to **process a large set of data**. The child can iterate over the data set calling
   Continue-As-New periodically without polluting the parents' history.
 
-- [**Cancellation**](https://github.com/temporalio/samples-go/tree/master/cancellation): Demonstrates how to cancel a
+- [**Cancellation**](cancellation): Demonstrates how to cancel a
   Workflow Execution by calling `CancelWorkflow`, an how to defer an Activity Execution that "cleans up" after the
   Workflow Execution has been cancelled.
 
 - **Coroutines**: Do not use native `go` routines in Workflows. Instead use Temporal coroutines (`workflow.Go()`) to
-  maintain a [deterministic](https://docs.temporal.io/docs/go/workflows/#how-to-write-workflow-code) Workflow. Can be
-  seen in the [Goroutine](https://github.com/temporalio/samples-go/tree/master/goroutine)
-  , [DSL](https://github.com/temporalio/samples-go/tree/master/dsl)
-  , [Recovery](https://github.com/temporalio/samples-go/tree/master/recovery)
-  , [PSO](https://github.com/temporalio/samples-go/tree/master/pso) Workflow examples.
+  maintain a [deterministic](https://docs.temporal.io/application-development/foundations/#develop-workflows) Workflow. Can be
+  seen in the [Goroutine](goroutine)
+  , [DSL](dsl)
+  , [Recovery](recovery)
+  , [PSO](pso) Workflow examples.
 
-- [**Cron Workflow**](https://github.com/temporalio/samples-go/tree/master/cron): Demonstrates a recurring Workflow
+- [**Cron Workflow**](cron): Demonstrates a recurring Workflow
   Execution that occurs according to a cron schedule. This samples showcases the `HasLastCompletionResult`
   and `GetLastCompletionResult` APIs which are used to pass information between executions. Additional
   documentation: [What is a Temporal Cron Job?](https://docs.temporal.io/docs/content/what-is-a-temporal-cron-job).
 
-- [**Encryption**](https://github.com/temporalio/samples-go/tree/master/encryption): How to use encryption for
+- [**Encryption**](encryption): How to use encryption for
   Workflow/Activity data with the DataConverter API. Also includes an example of stacking encoders (in this case
   encryption and compression)
-  . [Docs](https://docs.temporal.io/docs/go/workflows/#custom-serialization-and-workflow-security).
 
-- [**Codec Server**](https://github.com/temporalio/samples-go/tree/master/codec-server): Demonstrates using a codec
+- [**Codec Server**](codec-server): Demonstrates using a codec
   server to decode payloads for display in tctl and Temporal Web. This setup can be used for any kind of codec, common
   examples are compression or encryption.
 
-- [**Query Example**](https://github.com/temporalio/samples-go/tree/master/query): Demonstrates how to Query the state
+- [**Query Example**](query): Demonstrates how to Query the state
   of a single Workflow Execution using the `QueryWorkflow` and `SetQueryHandler` APIs. Additional
-  documentation: [How to Query a Workflow Execution in Go](https://docs.temporal.io/docs/go/queries).
+  documentation: [How to Query a Workflow Execution in Go](https://docs.temporal.io/application-development/features/#queries).
 
 - **Selectors**: Do not use the native Go `select` statement. Instead
   use [Go SDK Selectors](https://docs.temporal.io/docs/go/selectors) (`selector.Select(ctx)`) to maintain
-  a [deterministic](https://docs.temporal.io/docs/go/workflows/#how-to-write-workflow-code) Workflow. Can be seen in
-  the [Pick First](https://github.com/temporalio/samples-go/tree/master/pickfirst)
-  , [Mutex](https://github.com/temporalio/samples-go/tree/master/mutex)
-  , [DSL](https://github.com/temporalio/samples-go/tree/master/dsl),
+  a [deterministic](https://docs.temporal.io/application-development/foundations/#develop-workflows) Workflow. Can be seen in
+  the [Pick First](pickfirst)
+  , [Mutex](mutex)
+  , [DSL](dsl),
   and [Timer](https://github.com/temporalio/samples-go/tree/master/timer) examples.
 
 - **Sessions**: Demonstrates how to bind a set of Activity Executions to a specific Worker after the first Activity

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Server via the Temporal Go SDK.
 
 - Temporal Server repo: [https://github.com/temporalio/temporal](https://github.com/temporalio/temporal)
 - Temporal Go SDK repo: [https://github.com/temporalio/sdk-go](https://github.com/temporalio/sdk-go)
-- Go SDK docs: https://docs.temporal.io/docs/go/introduction
+- Go SDK docs: [https://docs.temporal.io/application-development](https://docs.temporal.io/application-development?lang=go#supported-sdks)
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Server via the Temporal Go SDK.
 - Or run Temporal Server locally with [VSCode Remote Containers](https://code.visualstudio.com/docs/remote/containers)
   . [![Open in Remote - Containers](https://img.shields.io/static/v1?label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/temporalio/samples-go)
 - Lastly, you can run Temporal Server locally on your own (follow
-  the [Quick install guide](https://docs.temporal.io/clusters/quick-install)), then clone this repository
+  the [Quick install guide](https://docs.temporal.io/application-development/foundations#run-a-development-cluster)), then clone this repository
 
 The [helloworld](./helloworld) sample is a good place to start.
 

--- a/README.md
+++ b/README.md
@@ -18,158 +18,157 @@ Server via the Temporal Go SDK.
 - Lastly, you can run Temporal Server locally on your own (follow
   the [Quick install guide](https://docs.temporal.io/clusters/quick-install)), then clone this repository
 
-The [helloworld](helloworld) sample is a good place to start.
+The [helloworld](https://github.com/temporalio/samples-go/tree/main/helloworld) sample is a good place to start.
 
 ## Samples directory
 
 Each sample demonstrates one feature of the SDK, together with tests.
 
-- [**Basic hello world**](helloworld): Simple example of a Workflow
+- [**Basic hello world**](https://github.com/temporalio/samples-go/tree/main/helloworld): Simple example of a Workflow
   Definition and an Activity Definition.
 
-- [**Basic mTLS hello world**](helloworldmtls): Simple example of a
+- [**Basic mTLS hello world**](https://github.com/temporalio/samples-go/tree/main/helloworldmtls): Simple example of a
   Workflow Definition and an Activity Definition using mTLS like Temporal Cloud.
 
 ### API demonstrations
 
 - **Async activity completion**: Example of
-  an [Expense reporting](expense) Workflow that communicates with a
+  an [Expense reporting](https://github.com/temporalio/samples-go/tree/main/expense) Workflow that communicates with a
   server API. Additional
   documentation: [How to complete an Activity Execution asynchronously in Go](https://docs.temporal.io/application-development/foundations/#develop-activities)
 
-- [**Retry Activity Execution**](retryactivity): This samples
+- [**Retry Activity Execution**](https://github.com/temporalio/samples-go/tree/main/retryactivity): This samples
   executes an unreliable Activity. The Activity is executed with a custom Retry Policy. If the Activity Execution fails,
   the Server will schedule a retry based on the Retry Policy. This Activity also includes a Heartbeat, which enables it
   to resume from the Activity Execution's last reported progress when it retries.
 
-- [**Child Workflow**](child-workflow): Demonstrates how to use
+- [**Child Workflow**](https://github.com/temporalio/samples-go/tree/main/child-workflow): Demonstrates how to use
   execute a Child Workflow from a Parent Workflow Execution. A Child Workflow Execution only returns to the Parent
   Workflow Execution after completing its last Run.
 
 - [**Child Workflow with
-  ContinueAsNew**](https://github.com/temporalio/samples-go/tree/master/child-workflow-continue-as-new): Demonstrates
+  ContinueAsNew**](https://github.com/temporalio/samples-go/tree/main/child-workflow-continue-as-new): Demonstrates
   that the call to Continue-As-New, by a Child Workflow Execution, is *not visible to the a parent*. The Parent Workflow
   Execution receives a notification only when a Child Workflow Execution completes, fails or times out. This is a useful
   feature when there is a need to **process a large set of data**. The child can iterate over the data set calling
   Continue-As-New periodically without polluting the parents' history.
 
-- [**Cancellation**](cancellation): Demonstrates how to cancel a
+- [**Cancellation**](https://github.com/temporalio/samples-go/tree/main/cancellation): Demonstrates how to cancel a
   Workflow Execution by calling `CancelWorkflow`, an how to defer an Activity Execution that "cleans up" after the
   Workflow Execution has been cancelled.
 
 - **Coroutines**: Do not use native `go` routines in Workflows. Instead use Temporal coroutines (`workflow.Go()`) to
   maintain a [deterministic](https://docs.temporal.io/application-development/foundations/#develop-workflows) Workflow. Can be
-  seen in the [Goroutine](goroutine)
-  , [DSL](dsl)
-  , [Recovery](recovery)
-  , [PSO](pso) Workflow examples.
+  seen in the [Goroutine](https://github.com/temporalio/samples-go/tree/main/goroutine)
+  , [DSL](https://github.com/temporalio/samples-go/tree/main/dsl)
+  , [Recovery](https://github.com/temporalio/samples-go/tree/main/recovery)
+  , [PSO](https://github.com/temporalio/samples-go/tree/main/pso) Workflow examples.
 
-- [**Cron Workflow**](cron): Demonstrates a recurring Workflow
+- [**Cron Workflow**](https://github.com/temporalio/samples-go/tree/main/cron): Demonstrates a recurring Workflow
   Execution that occurs according to a cron schedule. This samples showcases the `HasLastCompletionResult`
   and `GetLastCompletionResult` APIs which are used to pass information between executions. Additional
   documentation: [What is a Temporal Cron Job?](https://docs.temporal.io/docs/content/what-is-a-temporal-cron-job).
 
-- [**Encryption**](encryption): How to use encryption for
+- [**Encryption**](https://github.com/temporalio/samples-go/tree/main/encryption): How to use encryption for
   Workflow/Activity data with the DataConverter API. Also includes an example of stacking encoders (in this case
   encryption and compression)
 
-- [**Codec Server**](codec-server): Demonstrates using a codec
+- [**Codec Server**](https://github.com/temporalio/samples-go/tree/main/codec-server): Demonstrates using a codec
   server to decode payloads for display in tctl and Temporal Web. This setup can be used for any kind of codec, common
   examples are compression or encryption.
 
-- [**Query Example**](query): Demonstrates how to Query the state
+- [**Query Example**](https://github.com/temporalio/samples-go/tree/main/query): Demonstrates how to Query the state
   of a single Workflow Execution using the `QueryWorkflow` and `SetQueryHandler` APIs. Additional
   documentation: [How to Query a Workflow Execution in Go](https://docs.temporal.io/application-development/features/#queries).
 
 - **Selectors**: Do not use the native Go `select` statement. Instead
   use [Go SDK Selectors](https://docs.temporal.io/docs/go/selectors) (`selector.Select(ctx)`) to maintain
   a [deterministic](https://docs.temporal.io/application-development/foundations/#develop-workflows) Workflow. Can be seen in
-  the [Pick First](pickfirst)
-  , [Mutex](mutex)
-  , [DSL](dsl),
-  and [Timer](https://github.com/temporalio/samples-go/tree/master/timer) examples.
+  the [Pick First](https://github.com/temporalio/samples-go/tree/main/pickfirst)
+  , [Mutex](https://github.com/temporalio/samples-go/tree/main/mutex)
+  , [DSL](https://github.com/temporalio/samples-go/tree/main/dsl),
+  and [Timer](https://github.com/temporalio/samples-go/tree/main/timer) examples.
 
 - **Sessions**: Demonstrates how to bind a set of Activity Executions to a specific Worker after the first Activity
   executes. This feature is showcased in
-  the [File Processing example](https://github.com/temporalio/samples-go/tree/master/fileprocessing). Addition
-  documentation: [How to use Sessions in Go](https://docs.temporal.io/docs/go/sessions).
+  the [File Processing example](https://github.com/temporalio/samples-go/tree/main/fileprocessing). Addition
+  documentation: [How to use Sessions in Go](https://docs.temporal.io/go/how-to-create-a-worker-session-in-go).
 
-- **Signals**: Can be seen in the [Recovery](https://github.com/temporalio/samples-go/tree/master/recovery)
-  and [Mutex](https://github.com/temporalio/samples-go/tree/master/mutex) examples. Additional
-  documentation: [eCommerce application tutorial](https://docs.temporal.io/blog/tags/go-ecommerce-tutorial)
-  , [How to send a Signal to a Workflow Execution in Go](https://docs.temporal.io/docs/go/how-to-send-a-signal-to-a-workflow-execution-in-go)
-  , [How to handle a Signal in a Workflow Execution in Go](https://docs.temporal.io/docs/go/how-to-handle-a-signal-in-a-workflow-in-go)
+- **Signals**: Can be seen in the [Recovery](https://github.com/temporalio/samples-go/tree/main/recovery)
+  and [Mutex](https://github.com/temporalio/samples-go/tree/main/mutex) examples. Additional
+  documentation: [eCommerce application tutorial](https://learn.temporal.io/tutorials/go/ecommerce/)
+  , [How to send and handle Signals in Go](https://docs.temporal.io/application-development/features/#signals)
   .
 
-- [**Memo**](https://github.com/temporalio/samples-go/tree/master/memo): Demonstrates how to use Memo that can be used
+- [**Memo**](https://github.com/temporalio/samples-go/tree/main/memo): Demonstrates how to use Memo that can be used
   to store any kind of data.
 
-- [**Search Attributes**](https://github.com/temporalio/samples-go/tree/master/searchattributes): Demonstrates how to
+- [**Search Attributes**](https://github.com/temporalio/samples-go/tree/main/searchattributes): Demonstrates how to
   use custom Search Attributes that can be used to find Workflow Executions using predicates (must use
-  with [Elasticsearch](https://docs.temporal.io/docs/content/how-to-integrate-elasticsearch-into-a-temporal-cluster)).
+  with [Elasticsearch](https://docs.temporal.io/clusters/how-to-integrate-elasticsearch-into-a-temporal-cluster)).
 
-- [**Timer Futures**](https://github.com/temporalio/samples-go/tree/master/timer): The sample starts a long running
+- [**Timer Futures**](https://github.com/temporalio/samples-go/tree/main/timer): The sample starts a long running
   order processing operation and starts a Timer (`workflow.NewTimer()`). If the processing time is too long, a
   notification email is "sent" to the user regarding the delay (the execution does not cancel). If the operation
   finishes before the Timer fires, then the Timer is cancelled.
 
-- [**Tracing and Context Propagation**](https://github.com/temporalio/samples-go/tree/master/ctxpropagation):
+- [**Tracing and Context Propagation**](https://github.com/temporalio/samples-go/tree/main/ctxpropagation):
   Demonstrates the client initialization with a context propagator, which propagates specific information in
   the `context.Context` object across the Workflow Execution. The `context.Context` object is populated with information
   prior to calling `StartWorkflow`. This example demonstrates that the information is available in the Workflow
   Execution and Activity Executions. Additional
-  documentation: [How to use tracing in Go](https://docs.temporal.io/docs/go/tracing/).
+  documentation: [How to use tracing in Go](https://docs.temporal.io/go/tracing).
 
-- [**Updatable Timer**](https://github.com/temporalio/samples-go/tree/master/updatabletimer): Demonstrates timer
+- [**Updatable Timer**](https://github.com/temporalio/samples-go/tree/main/updatabletimer): Demonstrates timer
   cancellation and use of a Selector to wait on a Future and a Channel simultaneously.
 
-- [**Greetings**](https://github.com/temporalio/samples-go/tree/master/greetings): Demonstrates how to pass dependencies
+- [**Greetings**](https://github.com/temporalio/samples-go/tree/main/greetings): Demonstrates how to pass dependencies
   to activities defined as struct methods.
 
-- [**Greetings Local**](https://github.com/temporalio/samples-go/tree/master/greetingslocal): Demonstrates how to pass
+- [**Greetings Local**](https://github.com/temporalio/samples-go/tree/main/greetingslocal): Demonstrates how to pass
   dependencies to local activities defined as struct methods.
 
-- [**Interceptors**](https://github.com/temporalio/samples-go/tree/master/interceptor): Demonstrates how to use
+- [**Interceptors**](https://github.com/temporalio/samples-go/tree/main/interceptor): Demonstrates how to use
   interceptors to intercept calls, in this case for adding context to the logger.
 
 ### Dynamic Workflow logic examples
 
 These samples demonstrate some common control flow patterns using Temporal's Go SDK API.
 
-- [**Dynamic Execution**](https://github.com/temporalio/samples-go/tree/master/dynamic): Demonstrates how to execute
+- [**Dynamic Execution**](https://github.com/temporalio/samples-go/tree/main/dynamic): Demonstrates how to execute
   Workflows and Activities using a name rather than a strongly typed function.
 
-- [**Branching Acitivties**](https://github.com/temporalio/samples-go/blob/master/branch): Executes multiple Activities
+- [**Branching Acitivties**](https://github.com/temporalio/samples-go/tree/main/branch): Executes multiple Activities
   in parallel. The number of branches is controlled by a parameter that is passed in at the start of the Workflow
   Execution.
 
-- [**Exclusive Choice**](https://github.com/temporalio/samples-go/tree/master/choice-exclusive): Demonstrates how to
+- [**Exclusive Choice**](https://github.com/temporalio/samples-go/tree/main/choice-exclusive): Demonstrates how to
   execute Activities based on a dynamic input.
 
-- [**Multi-Choice**](https://github.com/temporalio/samples-go/tree/master/choice-multi): Demonstrates how to execute
+- [**Multi-Choice**](https://github.com/temporalio/samples-go/tree/main/choice-multi): Demonstrates how to execute
   multiple Activities in parallel based on a dynamic input.
 
-- [**Mutex Workflow**](https://github.com/temporalio/samples-go/tree/master/mutex): Demonstrates the ability to
+- [**Mutex Workflow**](https://github.com/temporalio/samples-go/tree/main/mutex): Demonstrates the ability to
   lock/unlock a particular resource within a particular Temporal Namespace. In this examples the other Workflow
   Executions within the same Namespace wait until a locked resource is unlocked. This shows how to avoid race conditions
   or parallel mutually exclusive operations on the same resource.
 
-- [**Goroutine Workflow**](https://github.com/temporalio/samples-go/tree/master/goroutine): This sample executes
+- [**Goroutine Workflow**](https://github.com/temporalio/samples-go/tree/main/goroutine): This sample executes
   multiple sequences of activities in parallel using the `workflow.Go()` API.
 
-- [**Pick First**](https://github.com/temporalio/samples-go/tree/master/pickfirst): This sample executes Activities in
+- [**Pick First**](https://github.com/temporalio/samples-go/tree/main/pickfirst): This sample executes Activities in
   parallel branches, picks the result of the branch that completes first, and then cancels other Activities that have
   not finished.
 
-- [**Split/Merge Future**](https://github.com/temporalio/samples-go/tree/master/splitmerge-future): Demonstrates how to
+- [**Split/Merge Future**](https://github.com/temporalio/samples-go/tree/main/splitmerge-future): Demonstrates how to
   use futures to await for completion of multiple activities invoked in parallel. This samples to processes chunks of a
   large work item in parallel, and then merges the intermediate results to generate the final result.
 -
-- [**Split/Merge Selector**](https://github.com/temporalio/samples-go/tree/master/splitmerge-selector): Demonstrates how
+- [**Split/Merge Selector**](https://github.com/temporalio/samples-go/tree/main/splitmerge-selector): Demonstrates how
   to use Selector to process activity results as soon as they become available. This samples to processes chunks of a
   large work item in parallel, and then merges the intermediate results to generate the final result.
 
-- [**Synchronous Proxy Workflow pattern**](https://github.com/temporalio/samples-go/tree/master/synchronous-proxy): This
+- [**Synchronous Proxy Workflow pattern**](https://github.com/temporalio/samples-go/tree/main/synchronous-proxy): This
   sample demonstrates a synchronous interaction with a "main" Workflow Execution from a "proxy" Workflow Execution. The
   proxy Workflow Execution sends a Signal to the "main" Workflow Execution, then blocks, waiting for a Signal in
   response.
@@ -182,31 +181,31 @@ These samples demonstrate some common control flow patterns using Temporal's Go 
 
 ### Scenario based examples
 
-- [**DSL Workflow**](https://github.com/temporalio/samples-go/tree/master/dsl): Demonstrates how to implement a
+- [**DSL Workflow**](https://github.com/temporalio/samples-go/tree/main/dsl): Demonstrates how to implement a
   DSL-based Workflow. This sample contains 2 yaml files that each define a custom "workflow" which instructs the
   Temporal Workflow. This is useful if you want to build in a "low code" layer.
 
-- [**Expense Request**](https://github.com/temporalio/samples-go/tree/master/expense): This demonstrates how to process
+- [**Expense Request**](https://github.com/temporalio/samples-go/tree/main/expense): This demonstrates how to process
   an expense request. This sample showcases how to complete an Activity Execution asynchronously.
 
-- [**File Processing**](https://github.com/temporalio/samples-go/tree/master/fileprocessing): Demonstrates how to
+- [**File Processing**](https://github.com/temporalio/samples-go/tree/main/fileprocessing): Demonstrates how to
   download and process a file using set of Activities that run on the same host. Activities are executed to download a
   file from the web, store it locally on the host, and then "process it". This samples showcases how to handle a
   scenario where all subsequent Activities need to execute on the same host as the first Activity in the sequence. In
   Go, this is achieved by using the Session APIs.
 
-- [**Particle Swarm Optimization**](https://github.com/temporalio/samples-go/tree/master/pso): Demonstrates how to
+- [**Particle Swarm Optimization**](https://github.com/temporalio/samples-go/tree/main/pso): Demonstrates how to
   perform a long iterative math optimization process using particle swarm optimization (PSO). This sample showcases the
   use of parallel executions, `ContinueAsNew` for long histories, a Query API, and the use of a custom `DataConverter`
   for serialization.
 
-- [**Prometheus Metrics**](https://github.com/temporalio/samples-go/tree/master/metrics): Demonstrates how to instrument
+- [**Prometheus Metrics**](https://github.com/temporalio/samples-go/tree/main/metrics): Demonstrates how to instrument
   Temporal with Prometheus and Uber's Tally library.
 
-- [**Request/Response with Response Activities**](https://github.com/temporalio/samples-go/tree/master/reqrespactivity):
+- [**Request/Response with Response Activities**](https://github.com/temporalio/samples-go/tree/main/reqrespactivity):
   Demonstrates how to accept requests via signals and use callback activities to push responses.
 
-- [**Request/Response with Response Queries**](https://github.com/temporalio/samples-go/tree/master/reqrespquery):
+- [**Request/Response with Response Queries**](https://github.com/temporalio/samples-go/tree/main/reqrespquery):
   Demonstrates how to accept requests via signals and use queries to poll for responses.
 
 ### Pending examples
@@ -218,9 +217,9 @@ Mostly examples we haven't yet ported from https://github.com/temporalio/samples
 - Periodic Workflow: Workflow that executes some logic periodically. *Example to be completed*
 - Exception propagation and wrapping: *Example to be completed*
 - Polymorphic activity: *Example to be completed*
-- Side Effect:  *Example to be completed* - [Docs](https://docs.temporal.io/docs/go/side-effect)
+- Side Effect:  *Example to be completed* - [Docs](https://docs.temporal.io/go/how-to-execute-a-side-effect-in-go)
 
 ### Fixtures
 
 These are edge case examples useful for Temporal internal development and bug
-reporting. [See their readme for more details](https://github.com/temporalio/samples-go/tree/master/temporal-fixtures).
+reporting. [See their readme for more details](https://github.com/temporalio/samples-go/tree/main/temporal-fixtures).

--- a/README.md
+++ b/README.md
@@ -18,194 +18,194 @@ Server via the Temporal Go SDK.
 - Lastly, you can run Temporal Server locally on your own (follow
   the [Quick install guide](https://docs.temporal.io/clusters/quick-install)), then clone this repository
 
-The [helloworld](https://github.com/temporalio/samples-go/tree/main/helloworld) sample is a good place to start.
+The [helloworld](./helloworld) sample is a good place to start.
 
 ## Samples directory
 
 Each sample demonstrates one feature of the SDK, together with tests.
 
-- [**Basic hello world**](https://github.com/temporalio/samples-go/tree/main/helloworld): Simple example of a Workflow
+- [**Basic hello world**](./helloworld): Simple example of a Workflow
   Definition and an Activity Definition.
 
-- [**Basic mTLS hello world**](https://github.com/temporalio/samples-go/tree/main/helloworldmtls): Simple example of a
+- [**Basic mTLS hello world**](./helloworldmtls): Simple example of a
   Workflow Definition and an Activity Definition using mTLS like Temporal Cloud.
 
 ### API demonstrations
 
 - **Async activity completion**: Example of
-  an [Expense reporting](https://github.com/temporalio/samples-go/tree/main/expense) Workflow that communicates with a
+  an [Expense reporting](./expense) Workflow that communicates with a
   server API. Additional
   documentation: [How to complete an Activity Execution asynchronously in Go](https://docs.temporal.io/application-development/foundations/#develop-activities)
 
-- [**Retry Activity Execution**](https://github.com/temporalio/samples-go/tree/main/retryactivity): This samples
+- [**Retry Activity Execution**](./retryactivity): This samples
   executes an unreliable Activity. The Activity is executed with a custom Retry Policy. If the Activity Execution fails,
   the Server will schedule a retry based on the Retry Policy. This Activity also includes a Heartbeat, which enables it
   to resume from the Activity Execution's last reported progress when it retries.
 
-- [**Child Workflow**](https://github.com/temporalio/samples-go/tree/main/child-workflow): Demonstrates how to use
+- [**Child Workflow**](./child-workflow): Demonstrates how to use
   execute a Child Workflow from a Parent Workflow Execution. A Child Workflow Execution only returns to the Parent
   Workflow Execution after completing its last Run.
 
 - [**Child Workflow with
-  ContinueAsNew**](https://github.com/temporalio/samples-go/tree/main/child-workflow-continue-as-new): Demonstrates
+  ContinueAsNew**](./child-workflow-continue-as-new): Demonstrates
   that the call to Continue-As-New, by a Child Workflow Execution, is *not visible to the a parent*. The Parent Workflow
   Execution receives a notification only when a Child Workflow Execution completes, fails or times out. This is a useful
   feature when there is a need to **process a large set of data**. The child can iterate over the data set calling
   Continue-As-New periodically without polluting the parents' history.
 
-- [**Cancellation**](https://github.com/temporalio/samples-go/tree/main/cancellation): Demonstrates how to cancel a
+- [**Cancellation**](./cancellation): Demonstrates how to cancel a
   Workflow Execution by calling `CancelWorkflow`, an how to defer an Activity Execution that "cleans up" after the
   Workflow Execution has been cancelled.
 
 - **Coroutines**: Do not use native `go` routines in Workflows. Instead use Temporal coroutines (`workflow.Go()`) to
   maintain a [deterministic](https://docs.temporal.io/application-development/foundations/#develop-workflows) Workflow. Can be
-  seen in the [Goroutine](https://github.com/temporalio/samples-go/tree/main/goroutine)
-  , [DSL](https://github.com/temporalio/samples-go/tree/main/dsl)
-  , [Recovery](https://github.com/temporalio/samples-go/tree/main/recovery)
-  , [PSO](https://github.com/temporalio/samples-go/tree/main/pso) Workflow examples.
+  seen in the [Goroutine](./goroutine)
+  , [DSL](./dsl)
+  , [Recovery](./recovery)
+  , [PSO](./pso) Workflow examples.
 
-- [**Cron Workflow**](https://github.com/temporalio/samples-go/tree/main/cron): Demonstrates a recurring Workflow
+- [**Cron Workflow**](./cron): Demonstrates a recurring Workflow
   Execution that occurs according to a cron schedule. This samples showcases the `HasLastCompletionResult`
   and `GetLastCompletionResult` APIs which are used to pass information between executions. Additional
   documentation: [What is a Temporal Cron Job?](https://docs.temporal.io/docs/content/what-is-a-temporal-cron-job).
 
-- [**Encryption**](https://github.com/temporalio/samples-go/tree/main/encryption): How to use encryption for
+- [**Encryption**](./encryption): How to use encryption for
   Workflow/Activity data with the DataConverter API. Also includes an example of stacking encoders (in this case
   encryption and compression)
 
-- [**Codec Server**](https://github.com/temporalio/samples-go/tree/main/codec-server): Demonstrates using a codec
+- [**Codec Server**](./codec-server): Demonstrates using a codec
   server to decode payloads for display in tctl and Temporal Web. This setup can be used for any kind of codec, common
   examples are compression or encryption.
 
-- [**Query Example**](https://github.com/temporalio/samples-go/tree/main/query): Demonstrates how to Query the state
+- [**Query Example**](./query): Demonstrates how to Query the state
   of a single Workflow Execution using the `QueryWorkflow` and `SetQueryHandler` APIs. Additional
   documentation: [How to Query a Workflow Execution in Go](https://docs.temporal.io/application-development/features/#queries).
 
 - **Selectors**: Do not use the native Go `select` statement. Instead
   use [Go SDK Selectors](https://docs.temporal.io/docs/go/selectors) (`selector.Select(ctx)`) to maintain
   a [deterministic](https://docs.temporal.io/application-development/foundations/#develop-workflows) Workflow. Can be seen in
-  the [Pick First](https://github.com/temporalio/samples-go/tree/main/pickfirst)
-  , [Mutex](https://github.com/temporalio/samples-go/tree/main/mutex)
-  , [DSL](https://github.com/temporalio/samples-go/tree/main/dsl),
-  and [Timer](https://github.com/temporalio/samples-go/tree/main/timer) examples.
+  the [Pick First](./pickfirst)
+  , [Mutex](./mutex)
+  , [DSL](./dsl),
+  and [Timer](./timer) examples.
 
 - **Sessions**: Demonstrates how to bind a set of Activity Executions to a specific Worker after the first Activity
   executes. This feature is showcased in
-  the [File Processing example](https://github.com/temporalio/samples-go/tree/main/fileprocessing). Addition
-  documentation: [How to use Sessions in Go](https://docs.temporal.io/go/how-to-create-a-worker-session-in-go).
+  the [File Processing example](./fileprocessing). Addition
+  documentation: [How to use Sessions in Go](https://docs.temporal.io/tasks/#sessions).
 
-- **Signals**: Can be seen in the [Recovery](https://github.com/temporalio/samples-go/tree/main/recovery)
-  and [Mutex](https://github.com/temporalio/samples-go/tree/main/mutex) examples. Additional
+- **Signals**: Can be seen in the [Recovery](./recovery)
+  and [Mutex](./mutex) examples. Additional
   documentation: [eCommerce application tutorial](https://learn.temporal.io/tutorials/go/ecommerce/)
   , [How to send and handle Signals in Go](https://docs.temporal.io/application-development/features/#signals)
   .
 
-- [**Memo**](https://github.com/temporalio/samples-go/tree/main/memo): Demonstrates how to use Memo that can be used
+- [**Memo**](./memo): Demonstrates how to use Memo that can be used
   to store any kind of data.
 
-- [**Search Attributes**](https://github.com/temporalio/samples-go/tree/main/searchattributes): Demonstrates how to
+- [**Search Attributes**](./searchattributes): Demonstrates how to
   use custom Search Attributes that can be used to find Workflow Executions using predicates (must use
-  with [Elasticsearch](https://docs.temporal.io/clusters/how-to-integrate-elasticsearch-into-a-temporal-cluster)).
+  with [Elasticsearch](https://docs.temporal.io/cluster-deployment-guide/#elasticsearch)).
 
-- [**Timer Futures**](https://github.com/temporalio/samples-go/tree/main/timer): The sample starts a long running
+- [**Timer Futures**](./timer): The sample starts a long running
   order processing operation and starts a Timer (`workflow.NewTimer()`). If the processing time is too long, a
   notification email is "sent" to the user regarding the delay (the execution does not cancel). If the operation
   finishes before the Timer fires, then the Timer is cancelled.
 
-- [**Tracing and Context Propagation**](https://github.com/temporalio/samples-go/tree/main/ctxpropagation):
+- [**Tracing and Context Propagation**](./ctxpropagation):
   Demonstrates the client initialization with a context propagator, which propagates specific information in
   the `context.Context` object across the Workflow Execution. The `context.Context` object is populated with information
   prior to calling `StartWorkflow`. This example demonstrates that the information is available in the Workflow
   Execution and Activity Executions. Additional
   documentation: [How to use tracing in Go](https://docs.temporal.io/go/tracing).
 
-- [**Updatable Timer**](https://github.com/temporalio/samples-go/tree/main/updatabletimer): Demonstrates timer
+- [**Updatable Timer**](./updatabletimer): Demonstrates timer
   cancellation and use of a Selector to wait on a Future and a Channel simultaneously.
 
-- [**Greetings**](https://github.com/temporalio/samples-go/tree/main/greetings): Demonstrates how to pass dependencies
+- [**Greetings**](./greetings): Demonstrates how to pass dependencies
   to activities defined as struct methods.
 
-- [**Greetings Local**](https://github.com/temporalio/samples-go/tree/main/greetingslocal): Demonstrates how to pass
+- [**Greetings Local**](./greetingslocal): Demonstrates how to pass
   dependencies to local activities defined as struct methods.
 
-- [**Interceptors**](https://github.com/temporalio/samples-go/tree/main/interceptor): Demonstrates how to use
+- [**Interceptors**](./interceptor): Demonstrates how to use
   interceptors to intercept calls, in this case for adding context to the logger.
 
 ### Dynamic Workflow logic examples
 
 These samples demonstrate some common control flow patterns using Temporal's Go SDK API.
 
-- [**Dynamic Execution**](https://github.com/temporalio/samples-go/tree/main/dynamic): Demonstrates how to execute
+- [**Dynamic Execution**](./dynamic): Demonstrates how to execute
   Workflows and Activities using a name rather than a strongly typed function.
 
-- [**Branching Acitivties**](https://github.com/temporalio/samples-go/tree/main/branch): Executes multiple Activities
+- [**Branching Acitivties**](./branch): Executes multiple Activities
   in parallel. The number of branches is controlled by a parameter that is passed in at the start of the Workflow
   Execution.
 
-- [**Exclusive Choice**](https://github.com/temporalio/samples-go/tree/main/choice-exclusive): Demonstrates how to
+- [**Exclusive Choice**](./choice-exclusive): Demonstrates how to
   execute Activities based on a dynamic input.
 
-- [**Multi-Choice**](https://github.com/temporalio/samples-go/tree/main/choice-multi): Demonstrates how to execute
+- [**Multi-Choice**](./choice-multi): Demonstrates how to execute
   multiple Activities in parallel based on a dynamic input.
 
-- [**Mutex Workflow**](https://github.com/temporalio/samples-go/tree/main/mutex): Demonstrates the ability to
+- [**Mutex Workflow**](./mutex): Demonstrates the ability to
   lock/unlock a particular resource within a particular Temporal Namespace. In this examples the other Workflow
   Executions within the same Namespace wait until a locked resource is unlocked. This shows how to avoid race conditions
   or parallel mutually exclusive operations on the same resource.
 
-- [**Goroutine Workflow**](https://github.com/temporalio/samples-go/tree/main/goroutine): This sample executes
+- [**Goroutine Workflow**](./goroutine): This sample executes
   multiple sequences of activities in parallel using the `workflow.Go()` API.
 
-- [**Pick First**](https://github.com/temporalio/samples-go/tree/main/pickfirst): This sample executes Activities in
+- [**Pick First**](./pickfirst): This sample executes Activities in
   parallel branches, picks the result of the branch that completes first, and then cancels other Activities that have
   not finished.
 
-- [**Split/Merge Future**](https://github.com/temporalio/samples-go/tree/main/splitmerge-future): Demonstrates how to
+- [**Split/Merge Future**](./splitmerge-future): Demonstrates how to
   use futures to await for completion of multiple activities invoked in parallel. This samples to processes chunks of a
   large work item in parallel, and then merges the intermediate results to generate the final result.
 -
-- [**Split/Merge Selector**](https://github.com/temporalio/samples-go/tree/main/splitmerge-selector): Demonstrates how
+- [**Split/Merge Selector**](./splitmerge-selector): Demonstrates how
   to use Selector to process activity results as soon as they become available. This samples to processes chunks of a
   large work item in parallel, and then merges the intermediate results to generate the final result.
 
-- [**Synchronous Proxy Workflow pattern**](https://github.com/temporalio/samples-go/tree/main/synchronous-proxy): This
+- [**Synchronous Proxy Workflow pattern**](./synchronous-proxy): This
   sample demonstrates a synchronous interaction with a "main" Workflow Execution from a "proxy" Workflow Execution. The
   proxy Workflow Execution sends a Signal to the "main" Workflow Execution, then blocks, waiting for a Signal in
   response.
 
-- [**Saga pattern**](https://github.com/temporalio/samples-go/tree/main/saga): This sample demonstrates how to implement
+- [**Saga pattern**](./saga): This sample demonstrates how to implement
   a saga pattern using golang defer feature.
 
-- [**Await for signal processing**](https://github.com/temporalio/samples-go/tree/main/await-signals): Demonstrates how
+- [**Await for signal processing**](./await-signals): Demonstrates how
   to process out of order signals processing using `Await` and `AwaitWithTimeout`.
 
 ### Scenario based examples
 
-- [**DSL Workflow**](https://github.com/temporalio/samples-go/tree/main/dsl): Demonstrates how to implement a
+- [**DSL Workflow**](./dsl): Demonstrates how to implement a
   DSL-based Workflow. This sample contains 2 yaml files that each define a custom "workflow" which instructs the
   Temporal Workflow. This is useful if you want to build in a "low code" layer.
 
-- [**Expense Request**](https://github.com/temporalio/samples-go/tree/main/expense): This demonstrates how to process
+- [**Expense Request**](./expense): This demonstrates how to process
   an expense request. This sample showcases how to complete an Activity Execution asynchronously.
 
-- [**File Processing**](https://github.com/temporalio/samples-go/tree/main/fileprocessing): Demonstrates how to
+- [**File Processing**](./fileprocessing): Demonstrates how to
   download and process a file using set of Activities that run on the same host. Activities are executed to download a
   file from the web, store it locally on the host, and then "process it". This samples showcases how to handle a
   scenario where all subsequent Activities need to execute on the same host as the first Activity in the sequence. In
   Go, this is achieved by using the Session APIs.
 
-- [**Particle Swarm Optimization**](https://github.com/temporalio/samples-go/tree/main/pso): Demonstrates how to
+- [**Particle Swarm Optimization**](./pso): Demonstrates how to
   perform a long iterative math optimization process using particle swarm optimization (PSO). This sample showcases the
   use of parallel executions, `ContinueAsNew` for long histories, a Query API, and the use of a custom `DataConverter`
   for serialization.
 
-- [**Prometheus Metrics**](https://github.com/temporalio/samples-go/tree/main/metrics): Demonstrates how to instrument
+- [**Prometheus Metrics**](./metrics): Demonstrates how to instrument
   Temporal with Prometheus and Uber's Tally library.
 
-- [**Request/Response with Response Activities**](https://github.com/temporalio/samples-go/tree/main/reqrespactivity):
+- [**Request/Response with Response Activities**](./reqrespactivity):
   Demonstrates how to accept requests via signals and use callback activities to push responses.
 
-- [**Request/Response with Response Queries**](https://github.com/temporalio/samples-go/tree/main/reqrespquery):
+- [**Request/Response with Response Queries**](./reqrespquery):
   Demonstrates how to accept requests via signals and use queries to poll for responses.
 
 ### Pending examples
@@ -217,9 +217,9 @@ Mostly examples we haven't yet ported from https://github.com/temporalio/samples
 - Periodic Workflow: Workflow that executes some logic periodically. *Example to be completed*
 - Exception propagation and wrapping: *Example to be completed*
 - Polymorphic activity: *Example to be completed*
-- Side Effect:  *Example to be completed* - [Docs](https://docs.temporal.io/go/how-to-execute-a-side-effect-in-go)
+- Side Effect:  *Example to be completed* - [Docs](https://docs.temporal.io/application-development/features?lang=go#side-effects)
 
 ### Fixtures
 
 These are edge case examples useful for Temporal internal development and bug
-reporting. [See their readme for more details](https://github.com/temporalio/samples-go/tree/main/temporal-fixtures).
+reporting. [See their readme for more details](./temporal-fixtures).

--- a/branch/README.md
+++ b/branch/README.md
@@ -1,6 +1,6 @@
 ## Parallel Activities
 <!-- @@@SNIPSTART samples-go-branch-readme -->
-Make sure the [Temporal Server is running locally](https://docs.temporal.io/clusters/quick-install).
+Make sure the [Temporal Server is running locally](https://docs.temporal.io/application-development/foundations#run-a-development-cluster).
 
 From the root of the project, start a Worker:
 

--- a/branch/README.md
+++ b/branch/README.md
@@ -1,6 +1,6 @@
 ## Parallel Activities
 <!-- @@@SNIPSTART samples-go-branch-readme -->
-Make sure the [Temporal Server is running locally](https://docs.temporal.io/docs/server/quick-install).
+Make sure the [Temporal Server is running locally](https://docs.temporal.io/clusters/quick-install).
 
 From the root of the project, start a Worker:
 

--- a/cancellation/README.md
+++ b/cancellation/README.md
@@ -1,6 +1,6 @@
 ## Cancellation
 <!-- @@@SNIPSTART samples-go-cancellation-readme -->
-Make sure the [Temporal Server is running locally](https://docs.temporal.io/clusters/quick-install).
+Make sure the [Temporal Server is running locally](https://docs.temporal.io/application-development/foundations#run-a-development-cluster).
 
 From the root of the project, start a Worker:
 

--- a/cancellation/README.md
+++ b/cancellation/README.md
@@ -1,6 +1,6 @@
 ## Cancellation
 <!-- @@@SNIPSTART samples-go-cancellation-readme -->
-Make sure the [Temporal Server is running locally](https://docs.temporal.io/docs/server/quick-install).
+Make sure the [Temporal Server is running locally](https://docs.temporal.io/clusters/quick-install).
 
 From the root of the project, start a Worker:
 

--- a/child-workflow-continue-as-new/README.md
+++ b/child-workflow-continue-as-new/README.md
@@ -6,7 +6,7 @@ Parent Workflow Executions receive a notification that a Child Workflow Executio
 This feature is very useful when there is a need to process a large set of data.
 The Child Execution can iterate over the data set, calling Continue-As-New periodically without polluting the parents' history.
 
-Make sure the [Temporal Server is running locally](https://docs.temporal.io/clusters/quick-install).
+Make sure the [Temporal Server is running locally](https://docs.temporal.io/application-development/foundations#run-a-development-cluster).
 
 Start the Worker:
 

--- a/child-workflow-continue-as-new/README.md
+++ b/child-workflow-continue-as-new/README.md
@@ -6,7 +6,7 @@ Parent Workflow Executions receive a notification that a Child Workflow Executio
 This feature is very useful when there is a need to process a large set of data.
 The Child Execution can iterate over the data set, calling Continue-As-New periodically without polluting the parents' history.
 
-Make sure the [Temporal Server is running locally](https://docs.temporal.io/docs/server/quick-install).
+Make sure the [Temporal Server is running locally](https://docs.temporal.io/clusters/quick-install).
 
 Start the Worker:
 

--- a/child-workflow/README.md
+++ b/child-workflow/README.md
@@ -1,6 +1,6 @@
 ## Child Workflow
 <!-- @@@SNIPSTART samples-go-child-workflow-example-readme -->
-Make sure the [Temporal Server is running locally](https://docs.temporal.io/docs/server/quick-install).
+Make sure the [Temporal Server is running locally](https://docs.temporal.io/clusters/quick-install).
 
 From the root of the project, start a Worker:
 

--- a/child-workflow/README.md
+++ b/child-workflow/README.md
@@ -1,6 +1,6 @@
 ## Child Workflow
 <!-- @@@SNIPSTART samples-go-child-workflow-example-readme -->
-Make sure the [Temporal Server is running locally](https://docs.temporal.io/clusters/quick-install).
+Make sure the [Temporal Server is running locally](https://docs.temporal.io/application-development/foundations#run-a-development-cluster).
 
 From the root of the project, start a Worker:
 

--- a/choice-exclusive/README.md
+++ b/choice-exclusive/README.md
@@ -3,7 +3,7 @@
 This sample demonstrates how to run an activity based on a dynamic input.
 
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
 go run choice-exclusive/worker/main.go

--- a/choice-multi/README.md
+++ b/choice-multi/README.md
@@ -3,7 +3,7 @@
 This sample demonstrates how to run multiple activities in parallel based on a dynamic input.
 
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
 go run choice-multi/worker/main.go

--- a/codec-server/README.md
+++ b/codec-server/README.md
@@ -3,7 +3,7 @@
 This sample shows how to decode payloads that have been encoded by a codec so they can be displayed by tctl and Temporal Web.
 The sample codec server supports OIDC authentication (via JWT in the Authorization header).
 Temporal Web can be configured to pass the user's OIDC access token to the codec server, see: https://github.com/temporalio/web#configuration
-Configuring OIDC is outside of the scope of this sample, but please see [../serverjwtauth](https://github.com/temporalio/samples-go/tree/main/serverjwtauth/) for more details about authentication.
+Configuring OIDC is outside of the scope of this sample, but please see the [serverjwtauth repo](../serverjwtauth/) for more details about authentication.
 
 1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker

--- a/codec-server/README.md
+++ b/codec-server/README.md
@@ -3,9 +3,9 @@
 This sample shows how to decode payloads that have been encoded by a codec so they can be displayed by tctl and Temporal Web.
 The sample codec server supports OIDC authentication (via JWT in the Authorization header).
 Temporal Web can be configured to pass the user's OIDC access token to the codec server, see: https://github.com/temporalio/web#configuration
-Configuring OIDC is outside of the scope of this sample, but please see [../serverjwtauth](../serverjwtauth/) for more details about authentication.
+Configuring OIDC is outside of the scope of this sample, but please see [../serverjwtauth](https://github.com/temporalio/samples-go/tree/main/serverjwtauth/) for more details about authentication.
 
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
 go run worker/main.go

--- a/cron/README.md
+++ b/cron/README.md
@@ -1,7 +1,7 @@
 This sample demonstrates how to setup cron based workflow.
 
 Steps to run this sample:
-1) You need a Temporal service running. See README.md for more details.
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run 
 ```
 go run cron/worker/main.go 

--- a/ctxpropagation/README.md
+++ b/ctxpropagation/README.md
@@ -13,7 +13,7 @@ $ docker run --publish 6831:6831 --publish 16686:16686 jaegertracing/all-in-one:
 ```
 
 Steps to run this sample:
-1) You need a Temporal service running. See details README.md.
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run
 ```
 go run ctxpropagation/worker/main.go

--- a/ctxpropagation/README.md
+++ b/ctxpropagation/README.md
@@ -1,5 +1,5 @@
 This sample Workflow demos context propagation through a Workflow. Details about context propagation are
-available [here](https://docs.temporal.io/docs/go/tracing).
+available [here](https://docs.temporal.io/tracing).
 
 The sample Workflow initializes the client with a context propagator which propagates
 specific information in the `context.Context` object across the Workflow. The `context.Context` object is populated

--- a/dsl/README.md
+++ b/dsl/README.md
@@ -1,7 +1,7 @@
 This sample demonstrates how to implement a DSL workflow. In this sample, we provide 2 sample yaml files each defines a custom workflow that can be processed by this DSL workflow sample code.
 
 Steps to run this sample:
-1) You need a Temporal service running. See README.md for more details.
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run
 ```
 go run dsl/worker/main.go

--- a/dynamic/README.md
+++ b/dynamic/README.md
@@ -4,7 +4,7 @@ The purpose of this sample is to demonstrate invocation of workflows and activit
 rather than strongly typed function.
 
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
 go run dynamic/worker/main.go

--- a/encryption/README.md
+++ b/encryption/README.md
@@ -1,5 +1,5 @@
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the remote codec server
 ```
 go run ./codec-server
@@ -22,4 +22,4 @@ tctl --codec_endpoint 'http://localhost:8081/' workflow show --wid encryption_wo
 ```
 
 Note: The codec server provided in this sample does not support decoding payloads for the Temporal Web UI, only tctl.
-Please see the [codec-server](../codec-server/) sample for a more complete example of a codec server which provides UI decoding and oauth.
+Please see the [codec-server](https://github.com/temporalio/samples-go/tree/main/codec-server/) sample for a more complete example of a codec server which provides UI decoding and oauth.

--- a/encryption/README.md
+++ b/encryption/README.md
@@ -22,4 +22,4 @@ tctl --codec_endpoint 'http://localhost:8081/' workflow show --wid encryption_wo
 ```
 
 Note: The codec server provided in this sample does not support decoding payloads for the Temporal Web UI, only tctl.
-Please see the [codec-server](https://github.com/temporalio/samples-go/tree/main/codec-server/) sample for a more complete example of a codec server which provides UI decoding and oauth.
+Please see the [codec-server](../codec-server/) sample for a more complete example of a codec server which provides UI decoding and oauth.

--- a/expense/README.md
+++ b/expense/README.md
@@ -14,6 +14,7 @@ the activity is not completed yet.
 * After the wait activity is completed, it does the payment for the expense (dummy step in this sample case).
 
 This sample relies on an a dummy expense server to work.
+Get a Temporal service running [here](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 
 # Steps To Run Sample
 * You need a Temporal service running. README.md for more details.

--- a/goroutine/README.md
+++ b/goroutine/README.md
@@ -5,7 +5,7 @@ function.
 
 ### Steps to run this sample:
 
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal Service](https://github.com/temporalio/samples-go/tree/main/#how-to-use)
 2) Run the following command to start the worker
 
 ```

--- a/greetings/README.md
+++ b/greetings/README.md
@@ -1,5 +1,5 @@
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
 go run greetings/worker/main.go

--- a/greetingslocal/README.md
+++ b/greetingslocal/README.md
@@ -1,5 +1,5 @@
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
 go run greetingslocal/worker/main.go

--- a/grpc-proxy/README.md
+++ b/grpc-proxy/README.md
@@ -3,7 +3,7 @@
 This sample shows how to compress payloads using a GRPC proxy. This allows managing the codec(s) centrally rather than needing to configure each client/worker.
 
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the GRPC proxy listening on port 8081
 ```
 go run proxy-server/main.go

--- a/helloworld/README.md
+++ b/helloworld/README.md
@@ -1,5 +1,5 @@
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
 go run helloworld/worker/main.go

--- a/helloworldmtls/README.md
+++ b/helloworldmtls/README.md
@@ -1,5 +1,6 @@
 ### Steps to run this sample:
-1) You need a Temporal server configured with mTLS such as Temporal cloud.
+1) Configure a [Temporal Server](https://github.com/temporalio/samples-go/tree/main/#how-to-use) (such as Temporal Cloud) with mTLS.
+
 2) Run the following command to start the worker
 ```
 go run ./helloworldmtls/worker -target-host my.namespace.tmprl.cloud:7233 -namespace my.namespace -client-cert path/to/cert.pem -client-key path/to/key.pem

--- a/interceptor/README.md
+++ b/interceptor/README.md
@@ -4,7 +4,7 @@ This sample shows how to make a worker interceptor that intercepts workflow and 
 the logger.
 
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
 go run ./interceptor/worker

--- a/memo/README.md
+++ b/memo/README.md
@@ -1,6 +1,6 @@
 ### Steps to run this sample:
 
-1) Before running this, you need to run Temporal Server 1.18+.
+1) Before running this, you need to run [Temporal Server 1.18+](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 
 2) Run the following command to start the worker:
 ```

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,5 +1,5 @@
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
 go run metrics/worker/main.go

--- a/multi-history-replay/README.md
+++ b/multi-history-replay/README.md
@@ -1,7 +1,7 @@
 This sample demonstrates getting multiple workflow histories and replaying them.
 
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```shell script
 go run multi-history-replay/worker/main.go

--- a/mutex/README.md
+++ b/mutex/README.md
@@ -13,7 +13,7 @@ and finally releases the lock once processing is over by sending `releaseLock` a
 
 
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
 go run mutex/worker/main.go

--- a/pickfirst/README.md
+++ b/pickfirst/README.md
@@ -1,5 +1,5 @@
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
 go run pickfirst/worker/main.go

--- a/pso/README.md
+++ b/pso/README.md
@@ -6,7 +6,7 @@ Since the data structure that maintains the optimization state has to be passed 
 Also the query API is supported to get the current state of running workflow.
 
 Steps to run this sample: 
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command multiple times on different console window. This is to simulate running workers on multiple different machines.
 ```
 go run pso/worker/main.go

--- a/query/README.md
+++ b/query/README.md
@@ -5,7 +5,7 @@ This sample workflow demos how to use query API to get the current state of runn
 `query_workflow_test.go` shows how to unit-test query functionality
 
 Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start worker
 ```
 go run query/worker/main.go

--- a/reqrespactivity/README.md
+++ b/reqrespactivity/README.md
@@ -9,7 +9,7 @@ via a response activity. This means the requester must have a worker running.
 
 Follow the below steps to run this sample:
 
-1) You need a Temporal service running. See details in README.md.
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 
 2) Run the following command in the background or in another terminal to run the worker:
 

--- a/reqrespquery/README.md
+++ b/reqrespquery/README.md
@@ -9,7 +9,7 @@ via a query. This means the requester must poll for response via queries.
 
 Follow the below steps to run this sample:
 
-1) You need a Temporal service running. See details in README.md.
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 
 2) Run the following command in the background or in another terminal to run the worker:
 

--- a/retryactivity/README.md
+++ b/retryactivity/README.md
@@ -1,5 +1,5 @@
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
 go run retryactivity/worker/main.go

--- a/saga/README.md
+++ b/saga/README.md
@@ -1,5 +1,5 @@
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
 go run saga/worker/main.go

--- a/searchattributes/README.md
+++ b/searchattributes/README.md
@@ -1,7 +1,7 @@
 ### Steps to run this sample:
-1) Before running this, Temporal Server need to run with an Advanced Visibility store (Elasticsearch integrated).
+1) Run [Temporal Server](Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use) with an Advanced Visibility store (Elasticsearch integrated).
 If you are using the default `docker-compose` config, then Elasticsearch is already integrated.
-If not, then you can [integrate Elasticsearch](https://docs.temporal.io/docs/content/how-to-integrate-elasticsearch-into-a-temporal-cluster) yourself.
+If not, then you can [integrate Elasticsearch](https://docs.temporal.io/clusters/how-to-integrate-elasticsearch-into-a-temporal-cluster) yourself.
 2) Run the following command to start the worker:
 ```
 go run searchattributes/worker/main.go

--- a/searchattributes/README.md
+++ b/searchattributes/README.md
@@ -1,7 +1,7 @@
 ### Steps to run this sample:
 1) Run [Temporal Server](Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use) with an Advanced Visibility store (Elasticsearch integrated).
 If you are using the default `docker-compose` config, then Elasticsearch is already integrated.
-If not, then you can [integrate Elasticsearch](https://docs.temporal.io/clusters/how-to-integrate-elasticsearch-into-a-temporal-cluster) yourself.
+If not, then you can [integrate Elasticsearch](https://docs.temporal.io/cluster-deployment-guide/#elasticsearch) yourself.
 2) Run the following command to start the worker:
 ```
 go run searchattributes/worker/main.go

--- a/serverjwtauth/README.md
+++ b/serverjwtauth/README.md
@@ -4,7 +4,7 @@ The Temporal server may be configured to authorize based on JWT sent as a header
 endpoint that hosts the public keys used to sign tokens (in JWK format, ref
 [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517)). Once the key's signature has been validated, the
 `permissions` claim in the token is used to determine what the caller can do. See
-[Temporal security documentation](https://docs.temporal.io/docs/security) for more details.
+[Temporal security documentation](https://docs.temporal.io/security) for more details.
 
 This example creates a ECDSA key pair, serves the public key for use by the server, and creates keys as needed for
 using `tctl`, running workers, and starting workflows.

--- a/serverjwtauth/README.md
+++ b/serverjwtauth/README.md
@@ -4,13 +4,13 @@ The Temporal server may be configured to authorize based on JWT sent as a header
 endpoint that hosts the public keys used to sign tokens (in JWK format, ref
 [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517)). Once the key's signature has been validated, the
 `permissions` claim in the token is used to determine what the caller can do. See
-[Temporal security documentation](https://docs.temporal.io/docs/server/security) for more details.
+[Temporal security documentation](https://docs.temporal.io/docs/security) for more details.
 
 This example creates a ECDSA key pair, serves the public key for use by the server, and creates keys as needed for
 using `tctl`, running workers, and starting workflows.
 
 Note: Since we are not authorizing the UI in this sample, the server UI will not work with this restricted access.
-[Configuration of SSO for the Temporal Web UI](https://github.com/temporalio/web#configuring-authentication-optional) is
+[Configuration of SSO for the Temporal Web UI](https://github.com/temporalio/web/#configuring-authentication-optional) is
 outside the scope of this example.
 
 ## Running
@@ -75,7 +75,7 @@ This will output something like:
 
     TEMPORAL_CLI_AUTH=Bearer abcde...
 
-See [this documentation](https://docs.temporal.io/docs/devtools/tctl/#run-the-cli) on how to run `tctl` with environment
+See [this documentation](https://docs.temporal.io/tctl-v1/#run-the-cli) on how to run `tctl` with environment
 variables. If using the docker approach from bash, an argument could be added like:
 
     --env "$(go run ./serverjwtauth/key tctl-system-token)"

--- a/snappycompress/README.md
+++ b/snappycompress/README.md
@@ -1,5 +1,5 @@
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Compile the snappycompress plugin for tctl
 ```
 go build -o ../bin/snappycompress-plugin plugin/main.go

--- a/splitmerge-future/README.md
+++ b/splitmerge-future/README.md
@@ -4,7 +4,7 @@ to see how to process them in the order of activity completion instead.
 
 ### Steps to run this sample:
 
-1) You need a Temporal service running. See details in README.md
+1) YRun a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 
 ```

--- a/splitmerge-selector/README.md
+++ b/splitmerge-selector/README.md
@@ -4,7 +4,7 @@ sample to see how to process them without Selector in the order of activity invo
 
 ### Steps to run this sample:
 
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 
 ```

--- a/synchronous-proxy/README.md
+++ b/synchronous-proxy/README.md
@@ -12,7 +12,7 @@ The flow of calls is outlined in the diagram below.
 
 ### Steps to run this sample:
 
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```shell
 go run worker/main.go

--- a/timer/README.md
+++ b/timer/README.md
@@ -1,5 +1,5 @@
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
 go run timer/worker/main.go

--- a/updatabletimer/README.md
+++ b/updatabletimer/README.md
@@ -10,7 +10,7 @@ Demonstrates:
 
 ### Steps to run this sample:
 
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 
 ```

--- a/zapadapter/README.md
+++ b/zapadapter/README.md
@@ -1,5 +1,5 @@
 ### Steps to run this sample:
-1) You need a Temporal service running. See details in README.md
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
 go run zaplogger/worker/main.go


### PR DESCRIPTION
## What was changed
Links were updated to reflect term changes in GitHub and updated content from the Docs team.

## Why?
These changes were made to direct users to relevant content, and to repair a few broken links.

How was this tested:
From any README file (I would use the main one), open the links provided to make sure they direct to the right pages. I would especially check anything that links to docs.temporal.io.

Any docs updates needed?
I'll check Go documents for any additional updates. That will be in a separate issue.
