### PR TITLE
Replace deprecated "io/ioutil" library

### DIFF
--- a/cancellation/workflow.go
+++ b/cancellation/workflow.go
@@ -1,10 +1,10 @@
 package cancellation
 
 import (
-	"fmt"
-	"time"
 	"errors"
+	"fmt"
 	"go.temporal.io/sdk/workflow"
+	"time"
 )
 
 // @@@SNIPSTART samples-go-cancellation-workflow-definition
@@ -20,11 +20,11 @@ func YourWorkflow(ctx workflow.Context) error {
 	logger.Info("cancel workflow started")
 	var a *Activities // Used to call Activities by function pointer
 	defer func() {
-		
+
 		if !errors.Is(ctx.Err(), workflow.ErrCanceled) {
 			return
 		}
-		
+
 		// When the Workflow is canceled, it has to get a new disconnected context to execute any Activities
 		newCtx, _ := workflow.NewDisconnectedContext(ctx)
 		err := workflow.ExecuteActivity(newCtx, a.CleanupActivity).Get(ctx, nil)

--- a/dsl/starter/main.go
+++ b/dsl/starter/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 	"flag"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/pborman/uuid"
 	"go.temporal.io/sdk/client"
@@ -18,7 +18,7 @@ func main() {
 	flag.StringVar(&dslConfig, "dslConfig", "dsl/workflow1.yaml", "dslConfig specify the yaml file for the dsl workflow.")
 	flag.Parse()
 
-	data, err := ioutil.ReadFile(dslConfig)
+	data, err := os.ReadFile(dslConfig)
 	if err != nil {
 		log.Fatalln("failed to load dsl config file", err)
 	}

--- a/expense/activities.go
+++ b/expense/activities.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -20,7 +20,7 @@ func CreateExpenseActivity(ctx context.Context, expenseID string) error {
 	if err != nil {
 		return err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	if err != nil {
 		return err
@@ -57,7 +57,7 @@ func WaitForDecisionActivity(ctx context.Context, expenseID string) (string, err
 		logger.Info("waitForDecisionActivity failed to register callback.", "Error", err)
 		return "", err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	if err != nil {
 		return "", err
@@ -86,7 +86,7 @@ func PaymentActivity(ctx context.Context, expenseID string) error {
 	if err != nil {
 		return err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	if err != nil {
 		return err

--- a/fileprocessing/activities.go
+++ b/fileprocessing/activities.go
@@ -2,7 +2,6 @@ package fileprocessing
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -40,7 +39,7 @@ func (a *Activities) ProcessFileActivity(ctx context.Context, fileName string) (
 	defer func() { _ = os.Remove(fileName) }() // cleanup temp file
 
 	// read downloaded file
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	if err != nil {
 		logger.Error("processFileActivity failed to read file.", "FileName", fileName, "Error", err)
 		return "", err
@@ -84,7 +83,7 @@ func (b *BlobStore) downloadFile(fileID string) []byte {
 
 func (b *BlobStore) uploadFile(ctx context.Context, filename string) error {
 	// dummy uploader
-	_, err := ioutil.ReadFile(filename)
+	_, err := os.ReadFile(filename)
 	for i := 0; i < 5; i++ {
 		time.Sleep(1 * time.Second)
 		// Demonstrates that heartbeat accepts progress data.
@@ -110,7 +109,7 @@ func transcodeData(ctx context.Context, data []byte) []byte {
 }
 
 func saveToTmpFile(data []byte) (f *os.File, err error) {
-	tmpFile, err := ioutil.TempFile("", "temporal_sample")
+	tmpFile, err := os.CreateTemp("", "temporal_sample")
 	if err != nil {
 		return nil, err
 	}

--- a/greetings/activities.go
+++ b/greetings/activities.go
@@ -12,6 +12,7 @@ type Activities struct {
 func (a *Activities) GetGreeting() (string, error) {
 	return a.Greeting, nil
 }
+
 // @@@SNIPEND
 
 // GetName Activity.

--- a/greetings/workflow.go
+++ b/greetings/workflow.go
@@ -37,7 +37,6 @@ func GreetingSample(ctx workflow.Context) (string, error) {
 		return "", err
 	}
 
-	
 	// Say Greeting.
 	var sayResult string
 	err = workflow.ExecuteActivity(ctx, a.SayGreeting, greetResult, nameResult).Get(ctx, &sayResult)

--- a/helloworld/replay_test.go
+++ b/helloworld/replay_test.go
@@ -32,7 +32,9 @@ func (s *replayTestSuite) TearDownTest() {
 
 // This replay test is the recommended way to make sure changing workflow code is backward compatible without non-deterministic errors.
 // "helloworld.json" can be downloaded from Temporal CLI:
-//      tctl wf show -w hello_world_workflowID --output_filename ./helloworld.json
+//
+//	tctl wf show -w hello_world_workflowID --output_filename ./helloworld.json
+//
 // Or from Temporal Web UI. And you may need to change workflowType in the first event.
 func (s *replayTestSuite) TestReplayWorkflowHistoryFromFile() {
 	replayer := worker.NewWorkflowReplayer()


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
* Replace deprecated `ioutil.ReadFile` with `os.ReadFile`
* Replace deprecated `ioutil.TempFile` with `os.CreateTemp`
* Replace deprecated `ioutil.ReadAll` with `io.ReadAll`

Used [gopatch](https://github.com/uber-go/gopatch) for automation:

`ioutil.patch`:
```
# Replace deprecated ioutil.ReadFile with os.ReadFile
# https://pkg.go.dev/io/ioutil#ReadFile
@@
@@
-import "io/ioutil"
+import "os"

-ioutil.ReadFile(...)
+os.ReadFile(...)

# Replace deprecated ioutil.TempFile with os.CreateTemp
# https://pkg.go.dev/io/ioutil#TempFile
@@
@@
-import "io/ioutil"
+import "os"

-ioutil.TempFile(...)
+os.CreateTemp(...)

# Replace deprecated ioutil.ReadAll with io.ReadAll
# https://pkg.go.dev/io/ioutil#ReadAll
@@
@@
-import "io/ioutil"
+import "io"

-ioutil.ReadAll(...)
+io.ReadAll(...)
```

Commands:
```
% gopatch -p ioutils.patch ./...

% go fmt ./...

% make errcheck
```

## Why?
`io/ioutil` is deprecated.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No
2. How was this tested:
`make errcheck`

3. Any docs updates needed?
No
