### PR TITLE
Add print result to greetings sample

### DIFF
--- a/greetings/starter/main.go
+++ b/greetings/starter/main.go
@@ -30,4 +30,12 @@ func main() {
 		log.Fatalln("Unable to execute workflow", err)
 	}
 	log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
+
+	// Synchronously wait for the workflow completion.
+	var result string
+	err = we.Get(context.Background(), &result)
+	if err != nil {
+		log.Fatalln("Unable get workflow result", err)
+	}
+	log.Println("Workflow result:", result)
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Adds the print of the result that is [present in the helloworld sample](https://github.com/temporalio/samples-go/blob/main/helloworld/starter/main.go#L31-L38).

The prior greetings sample starter printed:
```
go run ./greetings/starter/main.go
2023/03/05 09:43:27 INFO  No logger configured for temporal client. Created default one.
2023/03/05 09:43:27 Started workflow WorkflowID greetings_d8c94851-6878-4afe-a70b-c61185a7fd68 RunID 6ffb26cb-5164-4859-8974-1e32609f9cbc
```

The changed greeting sample starter prints:
```
go run ./greetings/starter/main.go
2023/03/05 09:43:27 INFO  No logger configured for temporal client. Created default one.
2023/03/05 09:43:27 Started workflow WorkflowID greetings_d8c94851-6878-4afe-a70b-c61185a7fd68 RunID 6ffb26cb-5164-4859-8974-1e32609f9cbc
2023/03/05 09:43:27 Workflow result: Greeting: Hello Temporal!
```

## Why?
<!-- Tell your future self why have you made these changes -->

It would be less confusing to a new temporal user if the starter waited for the workflow execution to complete, and printed the result.

I was confused when I originally ran this sample because I saw the worker run the workflow started by the starter, but the result wasn't printed by the starter. This sample is incrementally similar to the helloworld sample, so I expected a similar starter behavior. It seemed as if there was some sort of issue, maybe with how I was running the sample, but there isn't, there just wasn't a wait in the current greetings starter, like there is in helloworld.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

I'm honestly just learning the ropes with temporal. If there are automated tests for the starter's behavior, I don't know where they are yet. I ran the tests in the greetings package, and they passed. I also ran the sample code manually, using the docker compose in this project, and what seemed like the prescribed way of running the worker and starter in VS code.

Here's the full package go test output. I think the go1.17 warnings are a local system issue, but may indicate that some of the current vendor versions in go.sum are requiring go1.17 APIs. I did not change either go.mod or go.sum in this MR.
```
go test ./...
# golang.org/x/sys/unix
vendor/golang.org/x/sys/unix/syscall.go:83:16: unsafe.Slice requires go1.17 or later (-lang was set to go1.16; check go.mod)
vendor/golang.org/x/sys/unix/syscall_darwin.go:95:8: unsafe.Slice requires go1.17 or later (-lang was set to go1.16; check go.mod)
vendor/golang.org/x/sys/unix/syscall_unix.go:118:7: unsafe.Slice requires go1.17 or later (-lang was set to go1.16; check go.mod)
vendor/golang.org/x/sys/unix/sysvshm_unix.go:33:7: unsafe.Slice requires go1.17 or later (-lang was set to go1.16; check go.mod)
ok      github.com/temporalio/samples-go/activities-sticky-queues       0.749s
?       github.com/temporalio/samples-go/activities-sticky-queues/starter       [no test files]
?       github.com/temporalio/samples-go/activities-sticky-queues/worker        [no test files]
ok      github.com/temporalio/samples-go/await-signals  1.310s
?       github.com/temporalio/samples-go/await-signals/starter  [no test files]
?       github.com/temporalio/samples-go/await-signals/worker   [no test files]
ok      github.com/temporalio/samples-go/branch 0.954s
?       github.com/temporalio/samples-go/branch/starter [no test files]
?       github.com/temporalio/samples-go/branch/worker  [no test files]
?       github.com/temporalio/samples-go/cancellation   [no test files]
?       github.com/temporalio/samples-go/cancellation/cancel    [no test files]
?       github.com/temporalio/samples-go/cancellation/starter   [no test files]
?       github.com/temporalio/samples-go/cancellation/worker    [no test files]
?       github.com/temporalio/samples-go/child-workflow [no test files]
?       github.com/temporalio/samples-go/child-workflow/starter [no test files]
?       github.com/temporalio/samples-go/child-workflow/worker  [no test files]
?       github.com/temporalio/samples-go/child-workflow-continue-as-new [no test files]
?       github.com/temporalio/samples-go/child-workflow-continue-as-new/starter [no test files]
?       github.com/temporalio/samples-go/child-workflow-continue-as-new/worker  [no test files]
ok      github.com/temporalio/samples-go/choice-exclusive       0.969s
?       github.com/temporalio/samples-go/choice-exclusive/starter       [no test files]
?       github.com/temporalio/samples-go/choice-exclusive/worker        [no test files]
ok      github.com/temporalio/samples-go/choice-multi   1.254s
?       github.com/temporalio/samples-go/choice-multi/starter   [no test files]
?       github.com/temporalio/samples-go/choice-multi/worker    [no test files]
?       github.com/temporalio/samples-go/codec-server   [no test files]
ok      github.com/temporalio/samples-go/cron   0.588s
ok      github.com/temporalio/samples-go/ctxpropagation 0.832s
ok      github.com/temporalio/samples-go/dynamic        0.799s
ok      github.com/temporalio/samples-go/encryption     0.609s
ok      github.com/temporalio/samples-go/expense        1.287s
ok      github.com/temporalio/samples-go/fileprocessing 0.756s
ok      github.com/temporalio/samples-go/goroutine      0.597s
ok      github.com/temporalio/samples-go/greetings      0.764s
ok      github.com/temporalio/samples-go/greetingslocal 1.356s
ok      github.com/temporalio/samples-go/helloworld     1.118s
ok      github.com/temporalio/samples-go/helloworldmtls 1.230s
ok      github.com/temporalio/samples-go/interceptor    1.162s
ok      github.com/temporalio/samples-go/memo   0.593s
ok      github.com/temporalio/samples-go/mutex  0.590s
ok      github.com/temporalio/samples-go/pickfirst      1.187s
ok      github.com/temporalio/samples-go/polling/frequent       2.128s
ok      github.com/temporalio/samples-go/polling/infrequent     2.369s
ok      github.com/temporalio/samples-go/polling/periodic_sequence      2.376s
ok      github.com/temporalio/samples-go/pso    2.262s
ok      github.com/temporalio/samples-go/query  0.575s
ok      github.com/temporalio/samples-go/reqrespactivity        1.059s
ok      github.com/temporalio/samples-go/reqrespquery   0.522s
ok      github.com/temporalio/samples-go/retryactivity  1.545s
ok      github.com/temporalio/samples-go/saga   2.026s
ok      github.com/temporalio/samples-go/searchattributes       1.965s
ok      github.com/temporalio/samples-go/snappycompress 2.002s
ok      github.com/temporalio/samples-go/splitmerge-future      1.382s
ok      github.com/temporalio/samples-go/splitmerge-selector    1.885s
ok      github.com/temporalio/samples-go/temporal-fixtures/large-event-history  0.656s
ok      github.com/temporalio/samples-go/temporal-fixtures/largepayload 0.564s
ok      github.com/temporalio/samples-go/temporal-fixtures/openNclosed  0.529s
ok      github.com/temporalio/samples-go/temporal-fixtures/rainbow-statuses     0.522s
ok      github.com/temporalio/samples-go/temporal-fixtures/stuck-workflows      0.678s
ok      github.com/temporalio/samples-go/timer  0.548s
ok      github.com/temporalio/samples-go/updatabletimer 0.671s
```

2. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

Ran a text search for "greetings" and the [README.md](https://github.com/temporalio/samples-go/blob/main/README.md?plain=1#L125-L126) doesn't seem to refer to an expected output from the starter, so no doc changes seem to be needed.

