### PR TITLE
Add extra tests to pickfirst

### DIFF
--- a/pickfirst/pickfirst_workflow.go
+++ b/pickfirst/pickfirst_workflow.go
@@ -15,7 +15,7 @@ import (
  */
 
 // SamplePickFirstWorkflow workflow definition
-func SamplePickFirstWorkflow(ctx workflow.Context) error {
+func SamplePickFirstWorkflow(ctx workflow.Context) (string, error) {
 	selector := workflow.NewSelector(ctx)
 	var firstResponse string
 
@@ -59,7 +59,7 @@ func SamplePickFirstWorkflow(ctx workflow.Context) error {
 		_ = f.Get(ctx, nil)
 	}
 	workflow.GetLogger(ctx).Info("Workflow completed.")
-	return nil
+	return firstResponse, nil
 }
 
 func SampleActivity(ctx context.Context, currentBranchID int, totalDuration time.Duration) (string, error) {

--- a/pickfirst/pickfirst_workflow_test.go
+++ b/pickfirst/pickfirst_workflow_test.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
 )
 
 type UnitTestSuite struct {
@@ -34,5 +37,64 @@ func (s *UnitTestSuite) Test_Workflow() {
 
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
+
+	var result string
+	s.NoError(env.GetWorkflowResult(&result))
+	s.Equal("Branch 0 done in 1ns.", result)
 	env.AssertExpectations(s.T())
+}
+
+func (s *UnitTestSuite) Test_WorkflowBranchOne() {
+	env := s.NewTestWorkflowEnvironment()
+	env.RegisterActivity(SampleActivity)
+	// Use .After to test what happens if branch 1 finished before branch 0
+	env.OnActivity(SampleActivity, mock.Anything, 0, mock.Anything).After(5*time.Second).Return("Branch 0 done in 5s.", nil)
+	env.OnActivity(SampleActivity, mock.Anything, 1, mock.Anything).After(1*time.Second).Return("Branch 1 done in 1s.", nil)
+	env.ExecuteWorkflow(SamplePickFirstWorkflow)
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+
+	var result string
+	s.NoError(env.GetWorkflowResult(&result))
+	s.Equal("Branch 1 done in 1s.", result)
+	env.AssertExpectations(s.T())
+}
+
+func (s *UnitTestSuite) Test_CancelActivity() {
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestActivityEnvironment()
+	ctx, cancl := context.WithCancel(context.Background())
+	env.SetWorkerOptions(worker.Options{
+		BackgroundActivityContext: ctx,
+	})
+	env.RegisterActivity(SampleActivity)
+
+	go func() {
+		// Cancel the activity after 5s
+		time.Sleep(5 * time.Second)
+		cancl()
+	}()
+	_, err := env.ExecuteActivity(SampleActivity, 0, 10*time.Second)
+	// Expect the activity to return a cancled error
+	s.Error(err)
+}
+
+func (s *UnitTestSuite) Test_HeatbeatActivity() {
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestActivityEnvironment()
+
+	env.RegisterActivity(SampleActivity)
+	var heartBeatCount int
+	env.SetOnActivityHeartbeatListener(func(activityInfo *activity.Info, details converter.EncodedValues) {
+		var val string
+		err := details.Get(&val)
+		s.NoError(err)
+		s.Equal("status-report-to-workflow", val)
+		heartBeatCount++
+	})
+
+	_, err := env.ExecuteActivity(SampleActivity, 0, 5*time.Second)
+	s.NoError(err)
+	s.Equal(1, heartBeatCount)
 }


### PR DESCRIPTION
Add some extra tests to the `pickfirst` sample to show how to use some of the Go SDK test API. This way we can link all docs for https://github.com/temporalio/documentation/issues/1787 to samples.


All missing content and the sample that has a real example.
 - [ ] [Assert In Workflow](https://docs.temporal.io/application-development/testing?lang=go#assert-in-workflow)
  `await signals`
  - [ ] [Automatic Method](https://docs.temporal.io/application-development/testing?lang=go#automatic-method)
  `await signals`
  - [ ] [Cancel An Activity](https://docs.temporal.io/application-development/testing?lang=go#cancel-an-activity)
  `pickfirst`
  - [ ] [Listen To Heartbeats](https://docs.temporal.io/application-development/testing?lang=go#listen-to-heartbeats)
  `pickfirst`
  - [ ] [Manual Method](https://docs.temporal.io/application-development/testing?lang=go#manual-method)
  `await signals`
  - [ ] [Mock Activities](https://docs.temporal.io/application-development/testing?lang=go#mock-activities)
  `hello world`
  - [ ] [Run An Activity](https://docs.temporal.io/application-development/testing?lang=go#run-an-activity)
  `hello world`
  - [ ] [Skip Time In Activities](https://docs.temporal.io/application-development/testing?lang=go#skip-time-in-activities)
   `pickfirst`
  - [ ] [Test Frameworks](https://docs.temporal.io/application-development/testing?lang=go#test-frameworks)
  This whole repo
  - [ ] [Test Workflows](https://docs.temporal.io/application-development/testing?lang=go#test-workflows)
    `hello world`
