### PR TITLE
TW 49: added snipsync to schedule starter

### DIFF
--- a/schedule/starter/main.go
+++ b/schedule/starter/main.go
@@ -11,6 +11,7 @@ import (
 	"go.temporal.io/sdk/client"
 )
 
+// @@@SNIPSTART samples-go-schedule
 func main() {
 	ctx := context.Background()
 	// The client is a heavyweight object that should be created once per process.
@@ -116,3 +117,4 @@ func main() {
 		}
 	}
 }
+// @@@SNIPEND


### PR DESCRIPTION
## What was changed
Snipsync was added to the starter/main file for the Schedule code sample.

## Why?
Docs is creating a document about scheduling Workflows in Go, and needs code examples.

## Any docs updates needed?
Docs will update accordingly; once TW-49 is merged, the document will be there.
