### PR TITLE
Make server listen to all interfaces instead of just loopback

### DIFF
--- a/grpc-proxy/README.md
+++ b/grpc-proxy/README.md
@@ -6,15 +6,15 @@ This sample shows how to compress payloads using a GRPC proxy. This allows manag
 1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the GRPC proxy listening on port 8081
 ```
-go run proxy-server/main.go
+go run grpc-proxy/proxy-server/*.go
 ```
 3) Run the following command to start the worker. The worker is configured to connect to the proxy.
 ```
-go run worker/main.go
+go run grpc-proxy/worker/main.go
 ```
 4) Run the following command to start the example. The client the starter uses is configured to connect to the proxy.
 ```
-go run starter/main.go
+go run grpc-proxy/starter/main.go
 ```
 5) Run the following command and see that when tctl is connected directly to Temporal it cannot display the payloads as they are encoded (compressed)
 ```

--- a/grpc-proxy/proxy-server/main.go
+++ b/grpc-proxy/proxy-server/main.go
@@ -30,7 +30,7 @@ func init() {
 	flag.IntVar(&portFlag, "port", 8081, "Port to listen on")
 	flag.StringVar(&providerFlag, "provider", "", "OIDC Provider URL. Optional: Enforces oauth authentication")
 	flag.StringVar(&audienceFlag, "audience", "", "OIDC Audience. Optional.")
-	flag.StringVar(&upstreamFlag, "upstream", "127.0.0.1:7233", "Upstream Temporal Server Endpoint")
+	flag.StringVar(&upstreamFlag, "upstream", ":7233", "Upstream Temporal Server Endpoint")
 }
 
 func main() {
@@ -79,7 +79,7 @@ func main() {
 		)
 	}
 
-	listener, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(portFlag))
+	listener, err := net.Listen("tcp", ":"+strconv.Itoa(portFlag))
 	if err != nil {
 		logger.Fatal("unable to create listener: %v", tag.NewErrorTag(err))
 	}

--- a/grpc-proxy/starter/main.go
+++ b/grpc-proxy/starter/main.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"log"
 
-	grpcproxy "github.com/temporalio/samples-go/grpc-proxy"
 	"go.temporal.io/sdk/client"
+
+	grpcproxy "github.com/temporalio/samples-go/grpc-proxy"
 )
 
 func main() {


### PR DESCRIPTION
## What was changed

Update grpc-proxy server to listen to all network interfaces.

## Why?

We should not assume request always come from the loopback interface even for local dev environment. For example, if the server runs inside of a container, a request originated from either the host or another container is routed through the VM's interface instead of loopback.

This was originally reported on the forum:
https://community.temporal.io/t/running-temporal-proxy-server-in-docker/8107