### PR TITLE
Add update request response sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ Each sample demonstrates one feature of the SDK, together with tests.
   execute a Child Workflow from a Parent Workflow Execution. A Child Workflow Execution only returns to the Parent
   Workflow Execution after completing its last Run.
 
-- [**Child Workflow with
-  ContinueAsNew**](./child-workflow-continue-as-new): Demonstrates
+- [**Child Workflow with ContinueAsNew**](./child-workflow-continue-as-new): Demonstrates
   that the call to Continue-As-New, by a Child Workflow Execution, is *not visible to the a parent*. The Parent Workflow
   Execution receives a notification only when a Child Workflow Execution completes, fails or times out. This is a useful
   feature when there is a need to **process a large set of data**. The child can iterate over the data set calling
@@ -135,6 +134,9 @@ Each sample demonstrates one feature of the SDK, together with tests.
 - [**Interceptors**](./interceptor): Demonstrates how to use
   interceptors to intercept calls, in this case for adding context to the logger.
 
+- [**Update**](./update): Demonstrates how to create a workflow that reacts
+  to workflow update requests.
+
 ### Dynamic Workflow logic examples
 
 These samples demonstrate some common control flow patterns using Temporal's Go SDK API.
@@ -217,6 +219,9 @@ resource waiting its successful completion
 
 - [**Request/Response with Response Queries**](./reqrespquery):
   Demonstrates how to accept requests via signals and use queries to poll for responses.
+
+- [**Request/Response with Response Updates**](./reqrespupdate):
+  Demonstrates how to accept requests and responsond via updates.
 
 ### Pending examples
 

--- a/reqrespupdate/README.md
+++ b/reqrespupdate/README.md
@@ -1,0 +1,49 @@
+# Request/Response Sample with Update-Based Responses
+
+This sample demonstrates how to send a request and get a response from a Temporal workflow via an update.
+
+[Update](https://docs.temporal.io/workflows#update) is a new feature available for preview on [Temporal Server v1.21](https://github.com/temporalio/temporal/releases/tag/v1.21.0).
+
+### Running
+
+Follow the below steps to run this sample:
+
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use). Note, update is only supported on [Temporal Server v1.21](https://github.com/temporalio/temporal/releases/tag/v1.21.0)
+
+2) Update functionality is disabled by default but can be enabled per Namespace by setting the `frontend.enableUpdateWorkflowExecution` flag to true for that Namespace in dynamic config.
+
+3) Run the following command in the background or in another terminal to run the worker:
+
+    go run ./reqrespupdate/worker
+
+4) Run the following command to start the workflow:
+
+    go run ./reqrespupdate/starter
+
+5) Run the following command to uppercase a string every second:
+
+    go run ./reqrespupdate/request
+
+Multiple of those can be run on different terminals to confirm that the processes are independent.
+
+### Comparison with activity-based responses and query-based response
+
+There are two other samlples showing how to do a request response pattern under [reqrespactivity](../reqrespactivity) sample and the [reqrespquery](../reqrespquery). The update based approach is the supperior option, and once released, will be the recommend approach.
+
+
+### Explanation of continue-as-new
+
+Workflows cannot have infinitely-sized history and when the event count grows too large, `ContinueAsNew` can be returned
+to start a new one atomically. However, in order not to lose any data, update requests must be handles and any other futures
+that need to be reacted to must be completed first. This means there must be a period where there are no updates to
+process and no futures to wait on. If update requests come in faster than processed or futures wait so long there is no idle
+period, `ContinueAsNew` will not happen in a timely manner and history will grow.
+
+Since this sample is a long-running workflow, once the request count reaches a certain size, we perform a
+`ContinueAsNew`. To not lose any data, we only send this if there are no in-flight update requests or executing
+activities. An executing activity can mean it is busy retrying. Care must be taken designing these systems where they do
+not receive requests so frequent that they can never have a idle period to return a `ContinueAsNew`. Signals are usually
+fast to receive, so they are less of a problem. Waiting on activities (as a response to the request or as a response
+callback activity) can be a tougher problem. Since we rely on the response of the activity, activity must complete
+including all retries. Retry policies of these activities should be set balancing the resiliency needs with the need to
+have a period of idleness at some point.

--- a/reqrespupdate/README.md
+++ b/reqrespupdate/README.md
@@ -28,13 +28,13 @@ Multiple of those can be run on different terminals to confirm that the processe
 
 ### Comparison with activity-based responses and query-based response
 
-There are two other samlples showing how to do a request response pattern under [reqrespactivity](../reqrespactivity) sample and the [reqrespquery](../reqrespquery). The update based approach is the supperior option, and once released, will be the recommend approach.
+There are two other samples showing how to do a request response pattern under [reqrespactivity](../reqrespactivity) sample and the [reqrespquery](../reqrespquery). The update based approach is the superior option, and once released, will be the recommend approach.
 
 
 ### Explanation of continue-as-new
 
 Workflows cannot have infinitely-sized history and when the event count grows too large, `ContinueAsNew` can be returned
-to start a new one atomically. However, in order not to lose any data, update requests must be handles and any other futures
+to start a new one atomically. However, in order not to lose any data, update requests must be handled and any other futures
 that need to be reacted to must be completed first. This means there must be a period where there are no updates to
 process and no futures to wait on. If update requests come in faster than processed or futures wait so long there is no idle
 period, `ContinueAsNew` will not happen in a timely manner and history will grow.

--- a/reqrespupdate/request/main.go
+++ b/reqrespupdate/request/main.go
@@ -55,7 +55,7 @@ func main() {
 		if val, err := req.RequestUppercase(ctx, str); err != nil {
 			log.Printf("  Failed: %v", errors.Unwrap(err))
 			// Backoff so the workflow can continue as new
-			if errors.Unwrap(err).Error() == reqrespupdate.BackoffError.Error() {
+			if errors.Unwrap(err).Error() == reqrespupdate.ErrBackoff.Error() {
 				log.Printf("Workflow trying to continue as new, backing off")
 				time.Sleep(2 * time.Second)
 			}

--- a/reqrespupdate/request/main.go
+++ b/reqrespupdate/request/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"strconv"
+	"time"
+
+	"github.com/temporalio/samples-go/reqrespupdate"
+	"go.temporal.io/sdk/client"
+)
+
+func main() {
+	var opts reqrespupdate.RequesterOptions
+	flag.StringVar(&opts.TargetWorkflowID, "w", "reqrespupdate_workflow", "WorkflowID")
+	flag.Parse()
+
+	// Create client
+	var err error
+	opts.Client, err = client.Dial(client.Options{
+		HostPort: client.DefaultHostPort,
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer opts.Client.Close()
+
+	// Create requester
+	req, err := reqrespupdate.NewRequester(opts)
+	if err != nil {
+		log.Fatalln("Unable to create requester", err)
+	}
+
+	// Run until ctrl+c
+	log.Printf("Requesting every second until ctrl+c")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		<-c
+		cancel()
+	}()
+
+	// Request every second
+	t := time.NewTicker(1 * time.Second)
+	defer t.Stop()
+	for i := 0; ; i++ {
+		str := "foo" + strconv.Itoa(i)
+		log.Printf("Requesting %q be uppercased", str)
+		if val, err := req.RequestUppercase(ctx, str); err != nil {
+			log.Printf("  Failed: %v", errors.Unwrap(err))
+			// Backoff so the workflow can continue as new
+			if errors.Unwrap(err).Error() == reqrespupdate.BackoffError.Error() {
+				log.Printf("Workflow trying to continue as new, backing off")
+				time.Sleep(2 * time.Second)
+			}
+		} else {
+			log.Printf("  Result: %q", val)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+	}
+}

--- a/reqrespupdate/requester.go
+++ b/reqrespupdate/requester.go
@@ -1,0 +1,46 @@
+package reqrespupdate
+
+import (
+	"context"
+	"fmt"
+
+	"go.temporal.io/sdk/client"
+)
+
+// Requester can request uppercasing of strings.
+type Requester struct {
+	options RequesterOptions
+}
+
+// RequesterOptions are options for NewRequester.
+type RequesterOptions struct {
+	// Client to the Temporal server. Required.
+	Client client.Client
+	// ID of the workflow listening for signals to uppercase. Required.
+	TargetWorkflowID string
+}
+
+// NewRequester creates a new Requester for the given options.
+func NewRequester(options RequesterOptions) (*Requester, error) {
+	if options.Client == nil {
+		return nil, fmt.Errorf("client required")
+	} else if options.TargetWorkflowID == "" {
+		return nil, fmt.Errorf("target workflow required")
+	}
+	return &Requester{options}, nil
+}
+
+// RequestUppercase sends a request and returns a response.
+func (r *Requester) RequestUppercase(ctx context.Context, str string) (string, error) {
+	// Send request and poll on an interval for response
+	handle, err := r.options.Client.UpdateWorkflow(ctx, r.options.TargetWorkflowID, "", UpdateHandler, Request{Input: str})
+	if err != nil {
+		return "", fmt.Errorf("failed updating workflow: %w", err)
+	}
+	var response Response
+	err = handle.Get(ctx, &response)
+	if err != nil {
+		return "", fmt.Errorf("failed getting update response: %w", err)
+	}
+	return response.Output, nil
+}

--- a/reqrespupdate/starter/main.go
+++ b/reqrespupdate/starter/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/temporalio/samples-go/reqrespupdate"
+	"go.temporal.io/sdk/client"
+)
+
+func main() {
+	c, err := client.Dial(client.Options{
+		HostPort: client.DefaultHostPort,
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	workflowOptions := client.StartWorkflowOptions{
+		ID:        "reqrespupdate_workflow",
+		TaskQueue: "reqrespupdate",
+	}
+
+	we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, reqrespupdate.UppercaseWorkflow, true)
+	if err != nil {
+		log.Fatalln("Unable to execute workflow", err)
+	}
+	log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
+}

--- a/reqrespupdate/worker/main.go
+++ b/reqrespupdate/worker/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"log"
+
+	"github.com/temporalio/samples-go/reqrespupdate"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+)
+
+func main() {
+	c, err := client.Dial(client.Options{
+		HostPort: client.DefaultHostPort,
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	w := worker.New(c, "reqrespupdate", worker.Options{})
+
+	w.RegisterWorkflow(reqrespupdate.UppercaseWorkflow)
+	w.RegisterActivity(reqrespupdate.UppercaseActivity)
+
+	err = w.Run(worker.InterruptCh())
+	if err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+}

--- a/reqrespupdate/workflow.go
+++ b/reqrespupdate/workflow.go
@@ -85,6 +85,8 @@ func (u *uppercaser) run(ctx workflow.Context) error {
 	if u.rejectUpdateOnPendingContinueAsNew {
 		options.Validator = func(ctx workflow.Context, request Request) error {
 			if requestCount >= u.requestsBeforeContinueAsNew {
+				// Rejecting an update in the validator will not persist the update
+				// to history which is useful if the history size is growing large.
 				return ErrBackoff
 			}
 			return nil

--- a/reqrespupdate/workflow.go
+++ b/reqrespupdate/workflow.go
@@ -16,7 +16,7 @@ const (
 )
 
 var (
-	BackoffError = errors.New("trying to continue as new")
+	ErrBackoff = errors.New("trying to continue as new")
 )
 
 // UppercaseWorkflow is a workflow that accepts requests to uppercase strings
@@ -85,7 +85,7 @@ func (u *uppercaser) run(ctx workflow.Context) error {
 	if u.rejectUpdateOnPendingContinueAsNew {
 		options.Validator = func(ctx workflow.Context, request Request) error {
 			if requestCount >= u.requestsBeforeContinueAsNew {
-				return BackoffError
+				return ErrBackoff
 			}
 			return nil
 		}

--- a/reqrespupdate/workflow.go
+++ b/reqrespupdate/workflow.go
@@ -1,0 +1,119 @@
+package reqrespupdate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	UpdateHandler = "update"
+)
+
+var (
+	BackoffError = errors.New("trying to continue as new")
+)
+
+// UppercaseWorkflow is a workflow that accepts requests to uppercase strings
+// via updates and provides a response.
+func UppercaseWorkflow(ctx workflow.Context, rejectUpdateOnPendingContinueAsNew bool) error {
+	// Create and run the uppercaser. We choose to use a separate struct for this
+	// to make state management easier.
+	u, err := newUppercaser(ctx, rejectUpdateOnPendingContinueAsNew)
+	if err == nil {
+		err = u.run(ctx)
+	}
+	return err
+}
+
+// UppercaseActivity uppercases the given string.
+func UppercaseActivity(ctx context.Context, input string) (string, error) {
+	return strings.ToUpper(input), nil
+}
+
+// Request is a request to uppercase a string, passed as a update argument to
+// UppercaseWorkflow.
+type Request struct {
+	// String to be uppercased.
+	Input string `json:"input"`
+}
+
+// Response is a response to a Request. This is returned as a response to the update request
+type Response struct {
+	Output string `json:"output"`
+}
+
+type uppercaser struct {
+	workflow.Context
+	requestsBeforeContinueAsNew        int
+	rejectUpdateOnPendingContinueAsNew bool
+}
+
+func newUppercaser(ctx workflow.Context, rejectUpdateOnPendingContinueAsNew bool) (*uppercaser, error) {
+	u := &uppercaser{
+		// For the main context, we're only going to allow 1 retry and only a 5
+		// second schedule-to-close timeout. WARNING: The timeout and retry affect
+		// how long this workflow stays open and may prevent it from performing its
+		// continue-as-new until timeout occurs and/or retries are finished.
+		Context: workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+			ScheduleToCloseTimeout: 5 * time.Second,
+			RetryPolicy:            &temporal.RetryPolicy{MaximumAttempts: 2},
+		}),
+		// We'll allow 500 requests before we continue-as-new the workflow. This is
+		// required because the history will grow very large otherwise for an
+		// interminable workflow fielding update requests and executing activities.
+		requestsBeforeContinueAsNew: 500,
+		// If the workflow is trying to continue as new, but update requests are coming
+		// in faster than they are handled it is possible the workflow will never be able
+		// continue as new. To try to mitigate this the workflow can be set to reject incoming update
+		// through the validator. The requester will see this rejection and backoff.
+		rejectUpdateOnPendingContinueAsNew: rejectUpdateOnPendingContinueAsNew,
+	}
+	return u, nil
+}
+
+func (u *uppercaser) run(ctx workflow.Context) error {
+	var requestCount int
+	var pendingUpdates int
+
+	var options workflow.UpdateHandlerOptions
+	if u.rejectUpdateOnPendingContinueAsNew {
+		options.Validator = func(ctx workflow.Context, request Request) error {
+			if requestCount >= u.requestsBeforeContinueAsNew {
+				return BackoffError
+			}
+			return nil
+		}
+	}
+	// Set update handler
+	err := workflow.SetUpdateHandlerWithOptions(ctx, UpdateHandler, func(ctx workflow.Context, request Request) (Response, error) {
+		requestCount++
+		pendingUpdates++
+		defer func() {
+			pendingUpdates--
+		}()
+		var response Response
+		err := workflow.ExecuteActivity(u, UppercaseActivity, request.Input).Get(ctx, &response.Output)
+		return response, err
+	}, options)
+	if err != nil {
+		return fmt.Errorf("failed setting updatex handler: %w", err)
+	}
+
+	// Wait until we can continue as new or are cancelled.
+	err = workflow.Await(ctx, func() bool { return requestCount >= u.requestsBeforeContinueAsNew && pendingUpdates == 0 })
+	if err != nil {
+		return err
+	}
+
+	// Continue as new since there were too many responses and there is no pending updates.
+	// Note, if update requests come in faster than they
+	// are handled, there will not be a moment where the workflow has
+	// nothing pending which means this will run forever.
+	return workflow.NewContinueAsNewError(u, UppercaseWorkflow, u.rejectUpdateOnPendingContinueAsNew)
+}

--- a/reqrespupdate/workflow_test.go
+++ b/reqrespupdate/workflow_test.go
@@ -1,0 +1,66 @@
+package reqrespupdate_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/samples-go/reqrespupdate"
+	"go.temporal.io/sdk/testsuite"
+)
+
+type updateCallback struct {
+	accept   func()
+	reject   func(error)
+	complete func(interface{}, error)
+}
+
+func (uc *updateCallback) Accept() {
+	uc.accept()
+}
+
+func (uc *updateCallback) Reject(err error) {
+	uc.reject(err)
+}
+
+func (uc *updateCallback) Complete(success interface{}, err error) {
+	uc.complete(success, err)
+}
+
+func TestUppercaseWorkflow(t *testing.T) {
+	// Create env
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(reqrespupdate.UppercaseWorkflow)
+	env.RegisterActivity(reqrespupdate.UppercaseActivity)
+
+	// Use delayed callbacks to send enoguh updates to cause a continue as new
+	for i := 0; i < 550; i++ {
+		i := i
+		env.RegisterDelayedCallback(func() {
+			env.UpdateWorkflow(reqrespupdate.UpdateHandler, &updateCallback{
+				accept: func() {
+					if i >= 500 {
+						require.Fail(t, "update should fail since it should be trying to continue-as-new")
+					}
+				},
+				reject: func(err error) {
+					if i < 500 {
+						require.Fail(t, "this update should not fail")
+					}
+					require.Error(t, err)
+				},
+				complete: func(response interface{}, err error) {
+					if i >= 500 {
+						require.Fail(t, "update should fail since it should be trying to continue-as-new")
+					}
+					require.NoError(t, err)
+					require.Equal(t, reqrespupdate.Response{Output: fmt.Sprintf("FOO %d", i)}, response)
+				},
+			}, &reqrespupdate.Request{Input: fmt.Sprintf("foo %d", i)})
+		}, 1)
+	}
+
+	// Run workflow
+	env.ExecuteWorkflow(reqrespupdate.UppercaseWorkflow, true)
+}


### PR DESCRIPTION
Add a samples showing how to sue update for request/response pairs. I tried to match the structure of the existing samples to help users compare the old approaches with this new one.

Note: Since update is not released I held off fully recommending the update approach.