### PR TITLE
Allow to build a single sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ Each sample demonstrates one feature of the SDK, together with tests.
 - [**Basic mTLS hello world**](./helloworldmtls): Simple example of a
   Workflow Definition and an Activity Definition using mTLS like Temporal Cloud.
 
+## Building sampes
+
+To build all samples run this command:
+
+  $ make bins
+
+To build only a single sample run this command:
+
+  $ make bins <example-name>
+
+For example:
+
+  $ make bins helloworld
+
 ### API demonstrations
 
 - **Async activity completion**: Example of

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Each sample demonstrates one feature of the SDK, together with tests.
 - [**Basic mTLS hello world**](./helloworldmtls): Simple example of a
   Workflow Definition and an Activity Definition using mTLS like Temporal Cloud.
 
-## Building sampes
+## Building samples
 
 To build all samples run this command:
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added option to build a single sample

## Why?
Improving developer experience.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
No

2. How was this tested:
```
% make bins
Build sample for .
go build -o ./bin/./cancellation/cancel ././cancellation/cancel
go build -o ./bin/./cancellation/starter ././cancellation/starter
go build -o ./bin/./cancellation/worker ././cancellation/worker
go build -o ./bin/./encryption/codec-server ././encryption/codec-server
go build -o ./bin/./encryption/starter ././encryption/starter
go build -o ./bin/./encryption/worker ././encryption/worker
go build -o ./bin/./metrics/starter ././metrics/starter
...

% make bins helloworld
Build sample for helloworld
go build -o ./bin/helloworld/starter ./helloworld/starter
go build -o ./bin/helloworld/worker ./helloworld/worker
make: `helloworld' is up to date.
```

3. Any docs updates needed?
Added
