### PR TITLE
fix: os.WriteFile path error

### DIFF
--- a/activities-sticky-queues/activities.go
+++ b/activities-sticky-queues/activities.go
@@ -16,7 +16,7 @@ func DownloadFile(ctx context.Context, url, path string) error {
 	logger := activity.GetLogger(ctx)
 	logger.Info("Downloading file", "url", url, "path", path)
 	time.Sleep(3 * time.Second)
-	return os.WriteFile(url, []byte("Hello, Gophers!"), 0666)
+	return os.WriteFile(path, []byte("Hello, Gophers!"), 0666)
 }
 
 // ProcessFile is a stub function to processes a file.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
activities_sticky_queues
using url as the path parameter of os.WriteFile causes the code to not work

## Why?
<!-- Tell your future self why have you made these changes -->
Bugfix

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
