### PR TITLE
show use of DevServer to test

### DIFF
--- a/helloworld/helloworld_test.go
+++ b/helloworld/helloworld_test.go
@@ -1,12 +1,15 @@
 package helloworld
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
-
 	"github.com/stretchr/testify/require"
+
+	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
 )
 
 func Test_Workflow(t *testing.T) {
@@ -36,4 +39,64 @@ func Test_Activity(t *testing.T) {
 	var res string
 	require.NoError(t, val.Get(&res))
 	require.Equal(t, "Hello World!", res)
+}
+
+func Test_Using_DevServer(t *testing.T) {
+	//"" will let use a random port in local env
+	hostPort := ""
+	server, err := testsuite.StartDevServer(context.Background(), testsuite.DevServerOptions{ClientOptions: &client.Options{HostPort: hostPort}})
+	require.NoError(t, err)
+	require.NotNil(t, server)
+
+	var (
+		c       client.Client
+		w       worker.Worker
+		wInChan <-chan interface{}
+	)
+
+	taskQ := "hello-world"
+
+	ch := make(chan interface{})
+	go func() {
+		c = server.Client()
+		w = worker.New(c, taskQ, worker.Options{})
+		wInChan = worker.InterruptCh()
+
+		ch <- struct{}{}
+
+		_ = w.Run(wInChan)
+	}()
+
+	<-ch
+
+	require.NotNil(t, c)
+	require.NotNil(t, w)
+	require.NotNil(t, wInChan)
+
+	// register activity and workflow
+	w.RegisterWorkflow(Workflow)
+	w.RegisterActivity(Activity)
+
+	// run the workflow application (equivalent to starter/main.go)
+	workflowOptions := client.StartWorkflowOptions{
+		ID:        "hello_world_workflowID",
+		TaskQueue: taskQ,
+	}
+
+	we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, Workflow, "Temporal")
+	require.NoError(t, err)
+	require.NotNil(t, we)
+
+	// Synchronously wait for the workflow completion.
+	var result string
+	err = we.Get(context.Background(), &result)
+	require.NoError(t, err)
+	require.Equal(t, "Hello Temporal!", result)
+
+	// stop worker
+	w.Stop()
+
+	// stop server
+	err = server.Stop()
+	require.NoError(t, err)
 }


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added a test to "hello-world" sample to illustrate use of [DevServer](https://pkg.go.dev/go.temporal.io/sdk/testsuite#DevServer) 

## Why?
Show case DevServer as providing an alternative to testing workflows end-to-end as is without mocks.

## Checklist

1. ran make to verify changes
