### PR TITLE
Change link to avoid 404 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Server via the Temporal Go SDK.
 - Or run Temporal Server locally with [VSCode Remote Containers](https://code.visualstudio.com/docs/remote/containers)
   . [![Open in Remote - Containers](https://img.shields.io/static/v1?label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/temporalio/samples-go)
 - Lastly, you can run Temporal Server locally on your own (follow
-  the [Quick install guide](https://docs.temporal.io/application-development/foundations#run-a-development-cluster)), then clone this repository
+   [these instructions](https://learn.temporal.io/getting_started/go/dev_environment/)), then clone this repository
 
 The [helloworld](./helloworld) sample is a good place to start.
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I updated the target and text of the link that points to instructions on how to set up Temporal Service for local development. 

## Why?
<!-- Tell your future self why have you made these changes -->
The old link pointed to a page that no longer exists in the documentation. The text of that link used the title of that page, so it was not appropriate for the page to which it now links. 


## Checklist
<!--- add/delete as needed --->

1. Closes 

N/A

2. How was this tested:

I verified that the link appeared and functioned as expected in the GitHub Markdown preview. 

3. Any docs updates needed?

No