### PR TITLE
remove stale import from helloworld

### DIFF
--- a/helloworld/helloworld.go
+++ b/helloworld/helloworld.go
@@ -6,9 +6,6 @@ import (
 
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/workflow"
-
-	// TODO(cretz): Remove when tagged
-	_ "go.temporal.io/sdk/contrib/tools/workflowcheck/determinism"
 )
 
 // Workflow is a Hello World workflow definition.


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
The import doesn't seem to be necessary, and the TODO is 2 years old. Removing

## Why?
<!-- Tell your future self why have you made these changes -->
Clean things up

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
`make ci-build` passes locally

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
