### PR TITLE
Add missing argument to CAN call

### DIFF
--- a/safe_message_handler/workflow.go
+++ b/safe_message_handler/workflow.go
@@ -314,10 +314,14 @@ func (cm *ClusterManager) run(ctx workflow.Context) (ClusterManagerResult, error
 				return ClusterManagerResult{}, err
 			}
 			cm.logger.Info("Continuing as new")
-			return ClusterManagerResult{}, workflow.NewContinueAsNewError(ctx, ClusterManagerInput{
-				State:             &cm.state,
-				TestContinueAsNew: cm.testContinueAsNew,
-			})
+			return ClusterManagerResult{}, workflow.NewContinueAsNewError(
+				ctx,
+				ClusterManagerWorkflow,
+				ClusterManagerInput{
+					State:             &cm.state,
+					TestContinueAsNew: cm.testContinueAsNew,
+				},
+			)
 		}
 
 	}


### PR DESCRIPTION
It looks like Go's weak typing was letting us down here and allowing an incorrect call to get merged. Ideally we'd have a test that exercised the CAN.