### PR TITLE
Add nde example

### DIFF
--- a/nondeterminism/README.md
+++ b/nondeterminism/README.md
@@ -1,0 +1,17 @@
+# Non-deterministic error examples
+
+These samples showcase various cases in which you can run into non-deterministic errors. The steps explaining how to run the code such that such error is thrown are explained in each workflow sample.
+
+See [the deterministic constraints](https://docs.temporal.io/workflow-definition#deterministic-constraints) as a docs reference.
+
+### Steps to run this sample:
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
+2) Run the following command to start the worker
+```
+go run nondeterminism/worker/main.go
+```
+3) Run the following command to start the example
+```
+go run nondeterminism/starter/main.go
+```
+4) Check the instruction for each individual workflow to trigger the NDE

--- a/nondeterminism/nde_change_activity_name.go
+++ b/nondeterminism/nde_change_activity_name.go
@@ -1,0 +1,69 @@
+package nondeterminism
+
+import (
+	"context"
+	"time"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/workflow"
+)
+
+/*
+For all of the samples below, "nde" stands for non-deterministic error.
+*/
+
+/*
+The following similar scenarios DO NOT cause an NDE:
+- changing the activity's parameter name
+- changing an activity past the last checkpoint of the workflow, since the
+replay will not execute beyond the current checkpoint
+*/
+
+// WorkflowChangingActivityName shows how you can run into an nde if you just
+// change the name of an existing activity (e.g. if the previous name was not
+// representative). It is meant to show that refactoring must be handled with
+// care.
+//
+// Once the workflow reaches the sleep, shut down the worker, replace the
+// activity name with the new one and re-run the worker. To recover from this
+// nde, revert the activity name back to its original value and restart the
+// worker.
+func WorkflowChangingActivityName(ctx workflow.Context, parameter string) (string, error) {
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: 10 * time.Second,
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	logger := workflow.GetLogger(ctx)
+	logger.Info("HelloWorld workflow started", "parameter", parameter)
+
+	// replace ActivityOriginalName with ActivityNewName during the sleep to
+	// get an NDE.
+	workflow.ExecuteActivity(ctx, ActivityOriginalName, parameter).Get(ctx, nil)
+	// workflow.ExecuteActivity(ctx, ActivityNewName, parameter).Get(ctx, nil)
+	logger.Info("First activity completed")
+
+	logger.Info("sleeping...")
+	workflow.Sleep(ctx, 10*time.Second)
+
+	// replacing this during the sleep will not cause NDE
+	// workflow.ExecuteActivity(ctx, ActivityOriginalName, parameter).Get(ctx, nil)
+	workflow.ExecuteActivity(ctx, ActivityNewName, parameter).Get(ctx, nil)
+	logger.Info("Second activitys completed")
+
+	return "done", nil
+}
+
+func ActivityOriginalName(ctx context.Context, parameter string) error {
+	logger := activity.GetLogger(ctx)
+	logger.Info("Activity hello", "parameter", parameter)
+	return nil
+}
+
+// ActivityNewName is identical to ActivityOriginal in terms of signature and
+// implementation.
+func ActivityNewName(ctx context.Context, parameter string) error {
+	logger := activity.GetLogger(ctx)
+	logger.Info("Activity bye", "parameter", parameter)
+	return nil
+}

--- a/nondeterminism/starter/main.go
+++ b/nondeterminism/starter/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/temporalio/samples-go/nondeterminism"
+	"go.temporal.io/sdk/client"
+)
+
+func main() {
+	c, err := client.Dial(client.Options{})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	workflowOptions := client.StartWorkflowOptions{
+		ID:        "workflow_nde",
+		TaskQueue: "nde",
+	}
+
+	we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, nondeterminism.WorkflowChangingActivityName, "Temporal")
+	if err != nil {
+		log.Fatalln("Unable to execute workflow", err)
+	}
+
+	log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
+
+	var result string
+	err = we.Get(context.Background(), &result)
+	if err != nil {
+		log.Fatalln("Unable get workflow result", err)
+	}
+	log.Println("Workflow result:", result)
+}

--- a/nondeterminism/worker/main.go
+++ b/nondeterminism/worker/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"log"
+
+	"github.com/temporalio/samples-go/nondeterminism"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+)
+
+func main() {
+	// The client and worker are heavyweight objects that should be created once per process.
+	c, err := client.Dial(client.Options{})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	w := worker.New(c, "nde", worker.Options{})
+
+	w.RegisterWorkflow(nondeterminism.WorkflowChangingActivityName)
+	w.RegisterActivity(nondeterminism.ActivityOriginalName)
+	w.RegisterActivity(nondeterminism.ActivityNewName)
+
+	err = w.Run(worker.InterruptCh())
+	if err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+}


### PR DESCRIPTION
This PR is not ready -- I'm looking to gather some feedback on whether you like the format of this example. I'm going to extend this to cover multiple cases (e.g. branching logic, changing an Activity's argument type etc.) if you like the format.

## What was changed
Adds examples for how to obtain NDEs with Temporal. I will update this section further once the examples are complete.

## Why?
There is no explicit example on which actions can run into NDEs. Having those examples would be greatly beneficial for developers wondering if their change leads to an NDE. For example, I wasn't able to find in the docs if changing an Activity name (e.g. as part of a refactor) will lead to an NDE. The docs state

```
If a corresponding Event already exists within the Event History that maps to the generation of that Command in the same sequence, and some specific metadata of that Command matches with some specific metadata of the Event, then the Function Execution progresses.
[...]
If a generated Command doesn't match what it needs to in the existing Event History, then the Workflow Execution returns a non-deterministic error.
```
but it's not obvious what "needs to match". Obviously compiling an exhaustive list of all scenarios and keeping it up to date is probably not desirable, but I wanted to have a list of samples that cover common development use cases.
 
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
