### PR TITLE
ExecuteChildWorkflow interceptor sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,11 @@ Workflow Definition and an Activity Definition using API Key to authenticate wit
 - [**Greetings Local**](./greetingslocal): Demonstrates how to pass
   dependencies to local activities defined as struct methods.
 
-- [**Interceptors**](./interceptor): Demonstrates how to use
+- [**Logging Interceptor**](./logger-interceptor): Demonstrates how to use
   interceptors to intercept calls, in this case for adding context to the logger.
+
+- [**Workflow Security Interceptor**](./workflow-security-interceptor): Demonstrates how to use
+  interceptors to intercept child workflow calls, in this case for validating their type.
 
 - [**Update**](./update): Demonstrates how to create a workflow that reacts
   to workflow update requests.

--- a/logger-interceptor/README.md
+++ b/logger-interceptor/README.md
@@ -7,11 +7,11 @@ the logger.
 1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run the following command to start the worker
 ```
-go run ./interceptor/worker
+go run ./logger-interceptor/worker
 ```
 3) Run the following command to start the example
 ```
-go run ./interceptor/starter
+go run ./logger-interceptor/starter
 ```
 
 Notice the log output has the `WorkflowStartTime`/`ActivityStartTime` tags on the logs.

--- a/logger-interceptor/interceptor.go
+++ b/logger-interceptor/interceptor.go
@@ -1,4 +1,4 @@
-package interceptor
+package logger_interceptor
 
 import (
 	"context"

--- a/logger-interceptor/starter/main.go
+++ b/logger-interceptor/starter/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/temporalio/samples-go/interceptor"
+	"github.com/temporalio/samples-go/logger-interceptor"
 	"go.temporal.io/sdk/client"
 )
 
@@ -18,10 +18,10 @@ func main() {
 
 	workflowOptions := client.StartWorkflowOptions{
 		ID:        "interceptor_workflowID",
-		TaskQueue: "interceptor",
+		TaskQueue: "logger-interceptor",
 	}
 
-	we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, interceptor.Workflow, "Temporal")
+	we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, logger_interceptor.Workflow, "Temporal")
 	if err != nil {
 		log.Fatalln("Unable to execute workflow", err)
 	}

--- a/logger-interceptor/worker/main.go
+++ b/logger-interceptor/worker/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/temporalio/samples-go/interceptor"
+	"github.com/temporalio/samples-go/logger-interceptor"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	sdkinterceptor "go.temporal.io/sdk/interceptor"
@@ -21,9 +21,9 @@ func main() {
 	}
 	defer c.Close()
 
-	w := worker.New(c, "interceptor", worker.Options{
-		// Create interceptor that will put started time on the logger
-		Interceptors: []sdkinterceptor.WorkerInterceptor{interceptor.NewWorkerInterceptor(interceptor.InterceptorOptions{
+	w := worker.New(c, "logger-interceptor", worker.Options{
+		// Create logger-interceptor that will put started time on the logger
+		Interceptors: []sdkinterceptor.WorkerInterceptor{logger_interceptor.NewWorkerInterceptor(logger_interceptor.InterceptorOptions{
 			GetExtraLogTagsForWorkflow: func(ctx workflow.Context) []interface{} {
 				return []interface{}{"WorkflowStartTime", workflow.GetInfo(ctx).WorkflowStartTime.Format(time.RFC3339)}
 			},
@@ -33,8 +33,8 @@ func main() {
 		})},
 	})
 
-	w.RegisterWorkflow(interceptor.Workflow)
-	w.RegisterActivity(interceptor.Activity)
+	w.RegisterWorkflow(logger_interceptor.Workflow)
+	w.RegisterActivity(logger_interceptor.Activity)
 
 	err = w.Run(worker.InterruptCh())
 	if err != nil {

--- a/logger-interceptor/workflow.go
+++ b/logger-interceptor/workflow.go
@@ -1,4 +1,4 @@
-package interceptor
+package logger_interceptor
 
 import (
 	"context"

--- a/logger-interceptor/workflow_test.go
+++ b/logger-interceptor/workflow_test.go
@@ -1,11 +1,11 @@
-package interceptor_test
+package logger_interceptor_test
 
 import (
 	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/temporalio/samples-go/interceptor"
+	"github.com/temporalio/samples-go/logger-interceptor"
 	sdkinterceptor "go.temporal.io/sdk/interceptor"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/worker"
@@ -18,11 +18,11 @@ func TestWorkflow(t *testing.T) {
 	var capturingLogger capturingLogger
 	suite.SetLogger(&capturingLogger)
 	env := suite.NewTestWorkflowEnvironment()
-	env.RegisterActivity(interceptor.Activity)
+	env.RegisterActivity(logger_interceptor.Activity)
 
-	// Add our interceptor to put a custom tag on the logs
+	// Add our logger-interceptor to put a custom tag on the logs
 	env.SetWorkerOptions(worker.Options{
-		Interceptors: []sdkinterceptor.WorkerInterceptor{interceptor.NewWorkerInterceptor(interceptor.InterceptorOptions{
+		Interceptors: []sdkinterceptor.WorkerInterceptor{logger_interceptor.NewWorkerInterceptor(logger_interceptor.InterceptorOptions{
 			GetExtraLogTagsForWorkflow: func(workflow.Context) []interface{} {
 				return []interface{}{"workflow-tag", "workflow-value"}
 			},
@@ -33,7 +33,7 @@ func TestWorkflow(t *testing.T) {
 	})
 
 	// Run workflow
-	env.ExecuteWorkflow(interceptor.Workflow, "Temporal")
+	env.ExecuteWorkflow(logger_interceptor.Workflow, "Temporal")
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
 	var result string

--- a/workflow-security-interceptor/README.md
+++ b/workflow-security-interceptor/README.md
@@ -1,0 +1,22 @@
+# Child Workflow Type Validation Interceptor Sample
+
+This sample shows how to make a worker interceptor that intercepts child workflow requests. 
+The requests are validated using an activity. 
+Most of the sample complexity is in creating a custom implementation of a ChildWorkflowResult.
+
+
+### Steps to run this sample:
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
+2) Run the following command to start the worker
+```
+go run ./workflow-security-interceptor/worker
+```
+3) Run the following command to start the example
+```
+go run ./workflow-security-interceptor/starter
+```
+The expected output is workflow failure with the following message:
+```
+Child workflow type "UnallowedChildWorkflow" not allowed (type: not-allowed, retryable: true)
+```
+

--- a/workflow-security-interceptor/interceptor.go
+++ b/workflow-security-interceptor/interceptor.go
@@ -1,0 +1,115 @@
+package workflow_security_interceptor
+
+import (
+	"go.temporal.io/sdk/interceptor"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+	"time"
+)
+
+type workerInterceptor struct {
+	interceptor.WorkerInterceptorBase
+}
+
+func NewWorkerInterceptor() interceptor.WorkerInterceptor {
+	return &workerInterceptor{}
+}
+
+func (w *workerInterceptor) InterceptWorkflow(
+	ctx workflow.Context,
+	next interceptor.WorkflowInboundInterceptor,
+) interceptor.WorkflowInboundInterceptor {
+	i := &workflowInboundInterceptor{}
+	i.Next = next
+	return i
+}
+
+type workflowInboundInterceptor struct {
+	interceptor.WorkflowInboundInterceptorBase
+}
+
+func (w *workflowInboundInterceptor) Init(next interceptor.WorkflowOutboundInterceptor) error {
+	i := &workflowOutboundInterceptor{}
+	i.Next = next
+	return w.Next.Init(i)
+}
+
+type workflowOutboundInterceptor struct {
+	interceptor.WorkflowOutboundInterceptorBase
+}
+
+func ValidateChildWorkflowTypeActivity(childWorkflowType string) (bool, error) {
+	return childWorkflowType == "ChildWorkflow", nil
+}
+
+type validatedChildWorkflowFuture struct {
+	fAllowed   workflow.Future
+	sExecution workflow.Settable
+	fExecution workflow.Future
+	sResult    workflow.Settable
+	fResult    workflow.Future
+	child      workflow.ChildWorkflowFuture
+}
+
+func NewValidatedChildWorkflowFuture(ctx workflow.Context, allowed workflow.Future) *validatedChildWorkflowFuture {
+	r := &validatedChildWorkflowFuture{}
+	r.fAllowed = allowed
+	r.fExecution, r.sExecution = workflow.NewFuture(ctx)
+	r.fResult, r.sResult = workflow.NewFuture(ctx)
+	return r
+}
+
+func (v validatedChildWorkflowFuture) Get(ctx workflow.Context, valuePtr interface{}) error {
+	return v.fResult.Get(ctx, valuePtr)
+}
+
+func (v validatedChildWorkflowFuture) IsReady() bool {
+	return v.fResult.IsReady()
+}
+
+func (v validatedChildWorkflowFuture) GetChildWorkflowExecution() workflow.Future {
+	return v.fExecution
+}
+
+func (v validatedChildWorkflowFuture) SignalChildWorkflow(ctx workflow.Context, signalName string, data interface{}) workflow.Future {
+	f, s := workflow.NewFuture(ctx)
+	workflow.Go(ctx, func(ctx workflow.Context) {
+		// wait for validation
+		err := v.fAllowed.Get(ctx, nil)
+		if err != nil {
+			s.SetError(err)
+		}
+		s.Chain(v.child.SignalChildWorkflow(ctx, signalName, data))
+	})
+	return f
+}
+
+func (w *workflowOutboundInterceptor) ExecuteChildWorkflow(
+	ctx workflow.Context,
+	childWorkflowType string,
+	args ...interface{},
+) workflow.ChildWorkflowFuture {
+	aCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: time.Second * 10,
+	})
+	fAllowed := workflow.ExecuteActivity(aCtx, ValidateChildWorkflowTypeActivity, childWorkflowType)
+	result := NewValidatedChildWorkflowFuture(ctx, fAllowed)
+	workflow.Go(ctx, func(ctx workflow.Context) {
+		var allowed bool
+		err := fAllowed.Get(ctx, &allowed)
+		if err != nil {
+			result.sResult.SetError(err)
+			return
+		}
+		if !allowed {
+			result.sResult.SetError(temporal.NewApplicationError("Child workflow type \""+childWorkflowType+"\" not allowed", "not-allowed"))
+			return
+		}
+		childFuture := w.Next.ExecuteChildWorkflow(ctx, childWorkflowType, args...)
+		result.child = childFuture
+		result.sExecution.Chain(childFuture.GetChildWorkflowExecution())
+		result.sResult.Chain(childFuture)
+	})
+
+	return result
+}

--- a/workflow-security-interceptor/security_interceptor_test.go
+++ b/workflow-security-interceptor/security_interceptor_test.go
@@ -1,0 +1,31 @@
+package workflow_security_interceptor_test
+
+import (
+	"go.temporal.io/sdk/interceptor"
+	"go.temporal.io/sdk/worker"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
+
+	wsi "github.com/temporalio/samples-go/workflow-security-interceptor"
+)
+
+func TestSecurityInterceptorWorkflow(t *testing.T) {
+	var ts testsuite.WorkflowTestSuite
+	env := ts.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(worker.Options{
+		Interceptors: []interceptor.WorkerInterceptor{wsi.NewWorkerInterceptor()},
+	})
+	env.RegisterWorkflow(wsi.Workflow)
+	env.RegisterWorkflow(wsi.ChildWorkflow)
+	env.RegisterWorkflow(wsi.ProhibitedChildWorkflow)
+	env.RegisterActivity(wsi.ValidateChildWorkflowTypeActivity)
+
+	env.ExecuteWorkflow(wsi.Workflow)
+	err := env.GetWorkflowError()
+
+	require.Error(t, err, "expected prohibited child workflow to fail")
+	require.Contains(t, err.Error(), "Child workflow type \"ProhibitedChildWorkflow\" not allowed",
+		"expected error to contain prohibited child workflow type message")
+}

--- a/workflow-security-interceptor/starter/main.go
+++ b/workflow-security-interceptor/starter/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	securityinterceptor "github.com/temporalio/samples-go/logger-interceptor"
+	"log"
+
+	"go.temporal.io/sdk/client"
+)
+
+func main() {
+	// The client is a heavyweight object that should be created once per process.
+	c, err := client.Dial(client.Options{})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	workflowOptions := client.StartWorkflowOptions{
+		TaskQueue: "security-interceptor",
+	}
+
+	we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, securityinterceptor.Workflow, "Temporal")
+	if err != nil {
+		log.Fatalln("Unable to execute workflow", err)
+	}
+
+	log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
+
+	// Synchronously wait for the workflow completion.
+	var result string
+	err = we.Get(context.Background(), &result)
+	if err != nil {
+		log.Fatalln("Unable get workflow result", err)
+	}
+	log.Println("Workflow result:", result)
+}

--- a/workflow-security-interceptor/worker/main.go
+++ b/workflow-security-interceptor/worker/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	securityinterceptor "github.com/temporalio/samples-go/workflow-security-interceptor"
+	"go.temporal.io/sdk/client"
+	sdkinterceptor "go.temporal.io/sdk/interceptor"
+	"go.temporal.io/sdk/worker"
+	"log"
+)
+
+func main() {
+	// The client and worker are heavyweight objects that should be created once per process.
+	c, err := client.Dial(client.Options{})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	w := worker.New(c, "security-interceptor", worker.Options{
+		Interceptors: []sdkinterceptor.WorkerInterceptor{securityinterceptor.NewWorkerInterceptor()},
+	})
+	w.RegisterWorkflow(securityinterceptor.Workflow)
+	w.RegisterWorkflow(securityinterceptor.ChildWorkflow)
+	w.RegisterWorkflow(securityinterceptor.ProhibitedChildWorkflow)
+	// Activity used by the interceptor
+	w.RegisterActivity(securityinterceptor.ValidateChildWorkflowTypeActivity)
+
+	err = w.Run(worker.InterruptCh())
+	if err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+}

--- a/workflow-security-interceptor/workflow.go
+++ b/workflow-security-interceptor/workflow.go
@@ -1,0 +1,26 @@
+package workflow_security_interceptor
+
+import (
+	"go.temporal.io/sdk/workflow"
+)
+
+func ChildWorkflow(ctx workflow.Context) (string, error) {
+	return "OK", nil
+}
+
+func ProhibitedChildWorkflow(ctx workflow.Context) (string, error) {
+	return "OK", nil
+}
+
+func Workflow(ctx workflow.Context) error {
+	err := workflow.ExecuteChildWorkflow(ctx, ChildWorkflow).Get(ctx, nil)
+	if err != nil {
+		return err
+	}
+	// This will fail because the child workflow type is not allowed
+	err = workflow.ExecuteChildWorkflow(ctx, ProhibitedChildWorkflow).Get(ctx, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## What was changed
A sample demonstrating how to intercept `ExecuteChildWorkflow call`. The complexity is in implementing the ChildWorkflowResult interface.

## Why?
https://community.temporal.io/t/support-returning-a-failed-childworkflowfuture-from-interceptors/17472

