### PR TITLE
Tidy up service description

### DIFF
--- a/nexus/service/description.md
+++ b/nexus/service/description.md
@@ -1,8 +1,5 @@
-Service Name:
-	my-hello-service
-Operation Names:
-	echo
-	say-hello
+## Service: [my-hello-service](https://github.com/temporalio/samples-go/blob/main/nexus/service/api.go)
+ - operation: `echo`
+ - operation: `say-hello`
 
-Input / Output arguments are in the following repository:
-https://github.com/temporalio/samples-go/blob/main/nexus/service/api.go
+See https://github.com/temporalio/samples-go/blob/main/nexus/service/api.go for Input / Output types.


### PR DESCRIPTION
Convert the service description to markdown.

This is just a quick fix: we could make this more elaborate in subsequent PRs.

Rendered: https://github.com/temporalio/samples-go/blob/fix-nexus-descriptions/nexus/service/description.md