### PR TITLE
add note about schedules feature to cron examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ Workflow Definition and an Activity Definition using API Key to authenticate wit
   , [PSO](./pso) Workflow examples.
 
 - [**Cron Workflow**](./cron): Demonstrates a recurring Workflow
-  Execution that occurs according to a cron schedule. This sample showcases the `HasLastCompletionResult`
-  and `GetLastCompletionResult` APIs which are used to pass information between executions. Additional
-  documentation: [What is a Temporal Cron Job?](https://docs.temporal.io/docs/content/what-is-a-temporal-cron-job).
+  Execution that occurs according to a cron schedule. This sample showcases the `HasLastCompletionResult` and
+  `GetLastCompletionResult` APIs which are used to pass information between executions. **Note that we recommend
+  using Schedules instead of Cron Jobs.**
+  Additional documentation: [What is a Temporal Cron Job?](https://docs.temporal.io/docs/content/what-is-a-temporal-cron-job).
 
 - [**Schedule Workflow**](./schedule): Demonstrates a recurring Workflow
   Execution that occurs according to a schedule.

--- a/cron/README.md
+++ b/cron/README.md
@@ -1,5 +1,8 @@
 This sample demonstrates how to setup cron based workflow.
 
+
+**We recommend using [Schedules](../schedule) instead of Cron Jobs. Schedules were built to provide a better developer experience, including more configuration options and the ability to update or pause running Schedules.**
+
 Steps to run this sample:
 1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
 2) Run 


### PR DESCRIPTION
## What was changed

A very small, docs only change to signal to new users that they should consider the schedules feature over the cron feature.

## Why?
I'm new to temporal and learning from these samples. I needed a cron-style setup and didn't realize there was a superseding feature until my coworker noticed what I was doing and pointed it out.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:

Opened the two affected readme files in GitHub and spot checked them.
<!--- Please describe how you tested your changes/how we can test them -->

2. Any docs updates needed?

nope