### PR TITLE
Payload converter based on payload size

### DIFF
--- a/data-converter-large-payloads/README.md
+++ b/data-converter-large-payloads/README.md
@@ -1,0 +1,27 @@
+This sample shows an implementation of a payload converter that automatically detects workflow and activity payloads larger than a certain threshold and writes them to a file if that's the case.
+
+### Steps to run this sample:
+1) Run a [Temporal service](https://github.com/temporalio/samples-go/tree/main/#how-to-use).
+2) Run the following command to start the worker
+```
+go run data-converter-large-payloads/worker/main.go
+```
+3) Run the following command to start the example
+```
+go run data-converter-large-payloads/starter/main.go
+```
+
+For the inputs that exceed the Threshold, you should see them in the Temporal UI looking something like this:
+
+```
+{
+  "metadata": {
+    "encoding": "ZXhhbXBsZS9sb2NhbF9maWxl"
+  },
+  "data": "MDdkYjVhZTUtMGIyMC00OTRjLTk2NzgtNWExOGQwY2RiYmQ4"
+}
+```
+
+Contents are base64 encoded.
+
+The files specified by "data" (the decoded value) should be created locally.

--- a/data-converter-large-payloads/payloadconverter/data_converter.go
+++ b/data-converter-large-payloads/payloadconverter/data_converter.go
@@ -1,0 +1,136 @@
+package dataconverter
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/google/uuid"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/converter"
+)
+
+const (
+	MB                        = 1_000_000
+	MetadataEncodingLocalFile = "example/local_file"
+)
+
+// LargeSizePayloadConverter is a payload converter that detects if incoming
+// payloads are larger than a configurable threshold and if so, stores them to
+// a file instead of passing them directly to the Temporal server. The threshold
+// should be configured lower than the limit imposed by Temporal, which is 2MB.
+//
+// Note that other storage systems such as Postgres or S3 are a much better
+// choice than local files in scenarios other than development and testing.
+type LargeSizePayloadConverter struct {
+	// used for generating names of files
+	idGenerator idGenerator
+	// used to detect which payloads must be stored in files
+	threshold int
+}
+
+// idGenerator is used to generate the names of the files created for storing
+// the large payloads.
+type idGenerator interface {
+	NewString() string
+}
+
+// LargeSizePayloadConverterOption specifies configuration options for the
+// payload converter.
+type LargeSizePayloadConverterOption func(*LargeSizePayloadConverter)
+
+// WithThreshold sets the threshold from which payloads start to get written to
+// files. Payloads are stored as JSONs in files and the raw []byte JSON payload
+// length is compared to the threshold.
+func WithThreshold(sizeBytes int) LargeSizePayloadConverterOption {
+	return func(lspc *LargeSizePayloadConverter) {
+		lspc.threshold = sizeBytes
+	}
+}
+
+// NewLargeSizePayloadConverter creates new instance of
+// LargeSizePayloadConverter.
+//
+// Do not use this payload converter on its own! Because the converter only
+// applies to payloads larger than the threshold, there must be a fallback
+// converter for payloads whose size is lower than the threshold. Always use
+// this inside a composite payload converter.
+func NewLargeSizePayloadConverter(opts ...LargeSizePayloadConverterOption) *LargeSizePayloadConverter {
+	c := LargeSizePayloadConverter{
+		idGenerator: uuidv4IDGenerator{},
+		threshold:   1 * MB,
+	}
+
+	for _, opt := range opts {
+		opt(&c)
+	}
+
+	return &c
+}
+
+// ToPayload implements converter.PayloadConverter.
+func (c *LargeSizePayloadConverter) ToPayload(value any) (*commonpb.Payload, error) {
+
+	result, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal json: %w", err)
+	}
+
+	// will fallback on other registered converters
+	if len(result) < c.threshold {
+		return nil, nil
+	}
+
+	converter.NewJSONPayloadConverter()
+
+	filename := c.idGenerator.NewString()
+	err = os.WriteFile(filename, result, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write payload to file: %w", err)
+	}
+
+	return &commonpb.Payload{
+		Metadata: map[string][]byte{
+			converter.MetadataEncoding: []byte(MetadataEncodingLocalFile),
+		},
+		Data: []byte(filename),
+	}, nil
+}
+
+// FromPayload implements converter.PayloadConverter.
+func (c *LargeSizePayloadConverter) FromPayload(payload *commonpb.Payload, valuePtr any) error {
+
+	// This only gets called for payloads where the encoding is
+	// "example/local_file", in which case the file name is stored in the data.
+	filename := string(payload.Data)
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("failed to read payload from file: %w", err)
+	}
+
+	err = json.Unmarshal(data, valuePtr)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal payload: %w", err)
+	}
+
+	return nil
+}
+
+// ToString implements converter.PayloadConverter.
+func (c *LargeSizePayloadConverter) ToString(payload *commonpb.Payload) string {
+	// same as converter.JSONPayloadConverter
+	return string(payload.GetData())
+}
+
+// Encoding implements converter.PayloadConverter.
+func (c *LargeSizePayloadConverter) Encoding() string {
+	return MetadataEncodingLocalFile
+}
+
+var _ converter.PayloadConverter = &LargeSizePayloadConverter{}
+
+type uuidv4IDGenerator struct{}
+
+func (u uuidv4IDGenerator) NewString() string {
+	return uuid.NewString()
+}

--- a/data-converter-large-payloads/payloadconverter/data_converter_test.go
+++ b/data-converter-large-payloads/payloadconverter/data_converter_test.go
@@ -1,0 +1,240 @@
+package dataconverter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+
+	dclp "github.com/temporalio/samples-go/data-converter-large-payloads"
+)
+
+// testSequentialIDGenerator is a predictable ID generator, useful in tests to
+// validate the files being created by the data converter.
+type testSequentialIDGenerator struct {
+	start int
+}
+
+// NewString returns a file name with an integer suffix that is incremented
+// every call.
+func (t *testSequentialIDGenerator) NewString() string {
+	t.start++
+	return fmt.Sprintf("file-%02d", t.start)
+}
+
+// withSequentialIDGenerator is a helper function used to set the id
+// generator to a predictable one in tests.
+func withSequentialIDGenerator() LargeSizePayloadConverterOption {
+	return func(c *LargeSizePayloadConverter) {
+		c.idGenerator = &testSequentialIDGenerator{start: 0}
+	}
+}
+
+type LargePayloadsDataConverterTestSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+
+	env *testsuite.TestWorkflowEnvironment
+}
+
+func TestLargePayloadsDataConverterTestSuite(t *testing.T) {
+	suite.Run(t, new(LargePayloadsDataConverterTestSuite))
+}
+
+func (s *LargePayloadsDataConverterTestSuite) SetupTest() {
+	s.env = s.NewTestWorkflowEnvironment()
+}
+
+func (s *LargePayloadsDataConverterTestSuite) TearDownTest() {
+	// remove all the files that were created by the data converter
+	dir, err := os.ReadDir(".")
+	s.Require().NoError(err)
+	for _, d := range dir {
+		s.T().Logf("removig %s", d.Name())
+		if strings.HasPrefix(d.Name(), "file-") {
+			s.Require().NoError(os.Remove(d.Name()))
+		}
+	}
+}
+
+func (s *LargePayloadsDataConverterTestSuite) Test_DoesNotUseDataConverter_WhenNotExceedingThreshold() {
+
+	// Ensure threshold will never be exceeded.
+	s.env.SetDataConverter(converter.NewCompositeDataConverter(
+		converter.NewNilPayloadConverter(),
+		converter.NewByteSlicePayloadConverter(),
+		NewLargeSizePayloadConverter(WithThreshold(1000*1000*1000), withSequentialIDGenerator()),
+		converter.NewJSONPayloadConverter(),
+	))
+
+	dummyActivity := func(ctx context.Context, ainput *dclp.ValueContainer) (*dclp.ValueContainer, error) {
+		return ainput, nil
+	}
+	dummyWorkflow := func(ctx workflow.Context, winput *dclp.ValueContainer) (*dclp.ValueContainer, error) {
+		ao := workflow.ActivityOptions{
+			StartToCloseTimeout: 10 * time.Second,
+		}
+		ctx = workflow.WithActivityOptions(ctx, ao)
+		var result *dclp.ValueContainer
+		err := workflow.ExecuteActivity(ctx, dummyActivity, winput).Get(ctx, &result)
+		if err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+
+	s.env.RegisterWorkflow(dummyWorkflow)
+	s.env.RegisterActivity(dummyActivity)
+
+	input := dclp.ValueContainer{
+		Values: []dclp.CustomData{
+			{
+				Index: 1,
+				Name:  "name",
+			},
+		},
+	}
+	s.env.ExecuteWorkflow(dummyWorkflow, &input)
+
+	// then
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+
+	s.checkNoFilesWereCreated()
+}
+
+func (s *LargePayloadsDataConverterTestSuite) Test_UsesDataConverter_WhenExceedingThreshold() {
+
+	// Ensure threshold will always be exceeded.
+	s.env.SetDataConverter(converter.NewCompositeDataConverter(
+		converter.NewNilPayloadConverter(),
+		converter.NewByteSlicePayloadConverter(),
+		NewLargeSizePayloadConverter(WithThreshold(1), withSequentialIDGenerator()),
+		converter.NewJSONPayloadConverter(),
+	))
+
+	workflowInput := dclp.ValueContainer{
+		Values: []dclp.CustomData{
+			{
+				Name:  "workflow input",
+				Index: 0,
+			},
+		},
+	}
+	activityInput := dclp.ValueContainer{
+		Values: []dclp.CustomData{
+			{
+				Name:  "activity input",
+				Index: 1,
+			},
+		},
+	}
+	workflowResult := dclp.ValueContainer{
+		Values: []dclp.CustomData{
+			{
+				Name:  "workflow result",
+				Index: 2,
+			},
+		},
+	}
+	activityResult := dclp.ValueContainer{
+		Values: []dclp.CustomData{
+			{
+				Name:  "activity result",
+				Index: 3,
+			},
+		},
+	}
+
+	dummyActivity := func(ctx context.Context, ainput *dclp.ValueContainer) (*dclp.ValueContainer, error) {
+		return &activityResult, nil
+	}
+	dummyWorkflow := func(ctx workflow.Context, winput *dclp.ValueContainer) (*dclp.ValueContainer, error) {
+		ao := workflow.ActivityOptions{
+			StartToCloseTimeout: 10 * time.Second,
+		}
+		ctx = workflow.WithActivityOptions(ctx, ao)
+		err := workflow.ExecuteActivity(ctx, dummyActivity, &activityInput).Get(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+		return &workflowResult, nil
+	}
+
+	s.env.RegisterWorkflow(dummyWorkflow)
+	s.env.RegisterActivity(dummyActivity)
+
+	s.env.ExecuteWorkflow(dummyWorkflow, &workflowInput)
+
+	// then
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+
+	// The following files should be created:
+	// file-01 for calling the workflow
+	// file-02 for calling the activity
+	// file-03 for the activity return
+	// file-04 for the workflow return
+	s.checkOnlyFilesWereCreated("file-01", "file-02", "file-03", "file-04")
+}
+
+func (s *LargePayloadsDataConverterTestSuite) checkNoFilesWereCreated() {
+	s.checkOnlyFilesWereCreated()
+}
+
+// checkOnlyFilesWereCreated validates that only the file names passed as
+// argument were created by the data converter.
+func (s *LargePayloadsDataConverterTestSuite) checkOnlyFilesWereCreated(files ...string) {
+	s.T().Helper()
+
+	err := filepath.Walk(".", func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		s.T().Log("reading file", info.Name())
+
+		// skip current directory and go files in this directory
+		if path == "." || path[len(path)-3:] == ".go" {
+			return nil
+		}
+
+		if len(files) == 0 || !slices.Contains(files, path) {
+			return fmt.Errorf("unexpected path %s encountered", path)
+		}
+
+		return nil
+	})
+	s.Require().NoError(err)
+}
+
+// checkFileContent checks if the correct data is written to the file
+func (s *LargePayloadsDataConverterTestSuite) checkFileContent(file string, expected *dclp.ValueContainer) {
+	s.T().Helper()
+
+	f, err := os.Open(file)
+	s.Require().NoError(err)
+	defer f.Close()
+
+	d := json.NewDecoder(f)
+	var content *dclp.ValueContainer
+	err = d.Decode(&content)
+	s.Require().NoError(err)
+
+	s.Require().NotNil(content)
+	s.Require().Equal(len(expected.Values), len(content.Values))
+
+	for i := range len(expected.Values) {
+		s.Assert().Equal(expected.Values[i], content.Values[i])
+	}
+}

--- a/data-converter-large-payloads/starter/main.go
+++ b/data-converter-large-payloads/starter/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	dataconverterlargepayloads "github.com/temporalio/samples-go/data-converter-large-payloads"
+	pc "github.com/temporalio/samples-go/data-converter-large-payloads/payloadconverter"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/converter"
+)
+
+func main() {
+
+	dataconverter := converter.NewCompositeDataConverter(
+		converter.NewNilPayloadConverter(),
+		converter.NewByteSlicePayloadConverter(),
+		pc.NewLargeSizePayloadConverter(),
+		// fallback converter for payloads that do not exceed the threshold size
+		converter.NewJSONPayloadConverter(),
+	)
+
+	c, err := client.Dial(client.Options{
+		HostPort:      client.DefaultHostPort,
+		DataConverter: dataconverter,
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	workflowID := "default_workflow_id"
+	if len(os.Args) > 1 {
+		workflowID = os.Args[1]
+	}
+
+	workflowOptions := client.StartWorkflowOptions{
+		ID:        workflowID,
+		TaskQueue: "data-converter-large-payloads",
+	}
+
+	we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, dataconverterlargepayloads.Workflow)
+	if err != nil {
+		log.Fatalln("Unable to execute workflow", err)
+	}
+
+	log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
+
+	// Synchronously wait for the workflow completion.
+	var result string
+	err = we.Get(context.Background(), &result)
+	if err != nil {
+		log.Fatalln("Unable get workflow result", err)
+	}
+}

--- a/data-converter-large-payloads/worker/main.go
+++ b/data-converter-large-payloads/worker/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"log"
+
+	dataconverterlargepayloads "github.com/temporalio/samples-go/data-converter-large-payloads"
+	pc "github.com/temporalio/samples-go/data-converter-large-payloads/payloadconverter"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/worker"
+)
+
+func main() {
+
+	dataconverter := converter.NewCompositeDataConverter(
+		converter.NewNilPayloadConverter(),
+		converter.NewByteSlicePayloadConverter(),
+		pc.NewLargeSizePayloadConverter(),
+		// fallback converter for payloads that do not exceed the threshold size
+		converter.NewJSONPayloadConverter(),
+	)
+
+	c, err := client.Dial(client.Options{
+		HostPort:      client.DefaultHostPort,
+		DataConverter: dataconverter,
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	w := worker.New(c, "data-converter-large-payloads", worker.Options{})
+
+	w.RegisterWorkflow(dataconverterlargepayloads.Workflow)
+	w.RegisterActivity(dataconverterlargepayloads.Activity)
+
+	err = w.Run(worker.InterruptCh())
+	if err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+}

--- a/data-converter-large-payloads/workflow.go
+++ b/data-converter-large-payloads/workflow.go
@@ -1,0 +1,74 @@
+package dataconverterlargepayloads
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/workflow"
+)
+
+// Custom Data to send to temporal.
+type CustomData struct {
+	Index int    `json:"index"`
+	Name  string `json:"name"`
+}
+
+// Hold a lot of data.
+type ValueContainer struct {
+	Values []CustomData `json:"custom_data"`
+}
+
+func Workflow(ctx workflow.Context) error {
+
+	logger := workflow.GetLogger(ctx)
+
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Minute,
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	small := make([]CustomData, 0, 100)
+	for i := range 100 {
+		small = append(small, CustomData{
+			Index: i,
+			Name:  fmt.Sprintf("custom_data_%7d", i),
+		})
+	}
+	var retsmall *ValueContainer
+	err := workflow.ExecuteActivity(ctx, Activity, &ValueContainer{
+		Values: small,
+	}).Get(ctx, &retsmall)
+	if err != nil {
+		return fmt.Errorf("failed running small: %w", err)
+	}
+	logger.Info("Ran small", "first", retsmall.Values[0], "last", retsmall.Values[len(retsmall.Values)-1])
+
+	huge := make([]CustomData, 0, 100_000)
+	for i := range 100_000 {
+		huge = append(huge, CustomData{
+			Index: i,
+			Name:  fmt.Sprintf("custom_data_%7d", i),
+		})
+	}
+	var rethuge *ValueContainer
+	err = workflow.ExecuteActivity(ctx, Activity, &ValueContainer{
+		Values: huge,
+	}).Get(ctx, &rethuge)
+	if err != nil {
+		return fmt.Errorf("failed running huge: %w", err)
+	}
+	logger.Info("Ran huge", "first", rethuge.Values[0], "last", rethuge.Values[len(rethuge.Values)-1])
+
+	return nil
+}
+
+func Activity(ctx context.Context, input *ValueContainer) (*ValueContainer, error) {
+	logger := activity.GetLogger(ctx)
+
+	logger.Info("Got input", "total_values", len(input.Values))
+	logger.Info("Activity completed")
+
+	return input, nil
+}


### PR DESCRIPTION
This example shows how to implement a payload converter that detects when a payload is larger than a certain threshold, in which case it writes it to a storage system of choice instead of the temporal server. In this particular example payloads are written to a local file but it can be adapted to work with any storage. Such a converter is useful when a workflow/activity regularly has payloads that risk exceeding Temporal's hard limit of 2MB.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added a new sample.

## Why?
Two places where I worked required building something similar, so I thought it would be a good idea to write a sample for it. I haven't seen a similar sample available.

## Checklist

1. How was this tested:
Locally with Temporal cluster as well as unit tests available.

2. Any docs updates needed?
No
