### PR TITLE
fix(safe_message_handler): use state field for ClusterShutdown instead of local variable

### DIFF
--- a/safe_message_handler/workflow.go
+++ b/safe_message_handler/workflow.go
@@ -292,16 +292,15 @@ func (cm *ClusterManager) run(ctx workflow.Context) (ClusterManagerResult, error
 	cm.logger.Info("Cluster started")
 	for {
 		selector := workflow.NewSelector(ctx)
-		shouldShutdown := false
 		selector.AddReceive(cm.shutdownCh, func(c workflow.ReceiveChannel, _ bool) {
 			c.Receive(ctx, nil)
-			shouldShutdown = true
+			cm.state.ClusterShutdown = true
 		})
 		selector.AddFuture(workflow.NewTimer(ctx, cm.sleepInterval), func(f workflow.Future) {
 			cm.performHealthCheck(ctx)
 		})
 		selector.Select(ctx)
-		if shouldShutdown {
+		if cm.state.ClusterShutdown {
 			break
 		}
 		if cm.shouldContinueAsNew(ctx) {


### PR DESCRIPTION
## Summary

- `ClusterManagerState.ClusterShutdown` was checked in both `AssignNodesToJobs` and `DeleteJob` handlers to reject work after shutdown, but was never actually set to `true`
- Only a local `shouldShutdown` variable was being set in the shutdown signal handler, making the guard in the update handlers dead code
- Updates arriving during the `AllHandlersFinished` drain at shutdown could slip through and do real work
- Fix: replace `shouldShutdown` with `cm.state.ClusterShutdown` as the single source of truth for both the loop break condition and the update handler guards

## Test plan

- [ ] Run `go run safe_message_handler/worker/main.go` and `go run safe_message_handler/starter/main.go` and verify clean shutdown
- [ ] Verify update handlers correctly reject work after `ShutdownCluster` signal is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)