### PR TITLE
chore: Update and pin all GHA actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: Print build information
         run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: recursive
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.24"
       - name: CI Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,6 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: CI Build
         run: make ci-build

--- a/codec-server/go.mod
+++ b/codec-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/temporalio/samples-go/codec-server
 
-go 1.23.2
+go 1.25.0
 
 require (
 	github.com/golang/snappy v0.0.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/temporalio/samples-go
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/cactus/go-statsd-client => github.com/cactus/go-statsd-client/v5 v5.0.0
 

--- a/grpc-proxy/go.mod
+++ b/grpc-proxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/temporalio/samples-go/grpc-proxy
 
-go 1.23.2
+go 1.25.0
 
 require (
 	github.com/golang/snappy v0.0.4


### PR DESCRIPTION
## What changed

- Bump all GitHub Actions workflows to use latest "safe" releases.
  "Safe" is defined as the latest published release that is at least 2 weeks old (cooldown period).
- Pin all GHA actions usage to full SHA1, with a version comment.

## Why

- Improved security.
