### PR TITLE
googleadk: wire workers through the integration's plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -167,7 +167,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.shabbyrobe.org/gocovmerge v0.0.0-20230507111327-fa4f82cfbf4d // indirect
-	go.temporal.io/sdk/contrib/googleadk v0.1.0
+	go.temporal.io/sdk/contrib/googleadk v0.1.1-0.20260722181424-4e16e7db1f70
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org/intern v0.0.0-20230525184215-6c62f75575cb // indirect

--- a/go.mod
+++ b/go.mod
@@ -167,7 +167,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.shabbyrobe.org/gocovmerge v0.0.0-20230507111327-fa4f82cfbf4d // indirect
-	go.temporal.io/sdk/contrib/googleadk v0.1.1-0.20260722181424-4e16e7db1f70
+	go.temporal.io/sdk/contrib/googleadk v0.2.0
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org/intern v0.0.0-20230525184215-6c62f75575cb // indirect

--- a/go.sum
+++ b/go.sum
@@ -522,6 +522,8 @@ go.temporal.io/sdk/contrib/envconfig v1.0.1 h1:HZCcS6vNPJiUxJrkc5Wdeen+056LWmYe2
 go.temporal.io/sdk/contrib/envconfig v1.0.1/go.mod h1:aCFIuADlPNv6bYK5Zp4YfB/PnGfpiSPVzJfvaSTCYtw=
 go.temporal.io/sdk/contrib/googleadk v0.1.0 h1:ICu1nswKKu3TlO2hzVHRjdliZIq7aiUegGBMP5aCWMc=
 go.temporal.io/sdk/contrib/googleadk v0.1.0/go.mod h1:blDAd6sIyExkjtPP1Q52mUXHNJCfkRyWaNPtr51977g=
+go.temporal.io/sdk/contrib/googleadk v0.1.1-0.20260722181424-4e16e7db1f70 h1:oC2e7FKh+WrKaTrqdu0Ujh/vGLm7BG28YHnH6jh+Egs=
+go.temporal.io/sdk/contrib/googleadk v0.1.1-0.20260722181424-4e16e7db1f70/go.mod h1:blDAd6sIyExkjtPP1Q52mUXHNJCfkRyWaNPtr51977g=
 go.temporal.io/sdk/contrib/opentelemetry v0.7.0 h1:GSna1HP+1ibNXZ9xlVdQU2zFVqdt5VcdF0dzpeaYccQ=
 go.temporal.io/sdk/contrib/opentelemetry v0.7.0/go.mod h1:oQJC6UIl3FbSYh4f2MlUAIYSE6FPw02X1Tw8/bOvfxg=
 go.temporal.io/sdk/contrib/opentracing v0.3.0 h1:IKJgyvZiaOSFl0YHSxJpwXwQa08W3KaZCJkbx05rX7Q=

--- a/go.sum
+++ b/go.sum
@@ -520,10 +520,8 @@ go.temporal.io/sdk/contrib/datadog v0.5.0 h1:GfiDiqWNzkHqxO00H3Inxv66H+KLwS8ifz/
 go.temporal.io/sdk/contrib/datadog v0.5.0/go.mod h1:MeHebmCM0ujSoNk2P4b+inyPmcR4IOZqygCVgpekAls=
 go.temporal.io/sdk/contrib/envconfig v1.0.1 h1:HZCcS6vNPJiUxJrkc5Wdeen+056LWmYe2dI0D6UuB5g=
 go.temporal.io/sdk/contrib/envconfig v1.0.1/go.mod h1:aCFIuADlPNv6bYK5Zp4YfB/PnGfpiSPVzJfvaSTCYtw=
-go.temporal.io/sdk/contrib/googleadk v0.1.0 h1:ICu1nswKKu3TlO2hzVHRjdliZIq7aiUegGBMP5aCWMc=
-go.temporal.io/sdk/contrib/googleadk v0.1.0/go.mod h1:blDAd6sIyExkjtPP1Q52mUXHNJCfkRyWaNPtr51977g=
-go.temporal.io/sdk/contrib/googleadk v0.1.1-0.20260722181424-4e16e7db1f70 h1:oC2e7FKh+WrKaTrqdu0Ujh/vGLm7BG28YHnH6jh+Egs=
-go.temporal.io/sdk/contrib/googleadk v0.1.1-0.20260722181424-4e16e7db1f70/go.mod h1:blDAd6sIyExkjtPP1Q52mUXHNJCfkRyWaNPtr51977g=
+go.temporal.io/sdk/contrib/googleadk v0.2.0 h1:cAcwnRb86qf6pdBMYEWmcfP8d5aPSjiFWJw5ctGUZYI=
+go.temporal.io/sdk/contrib/googleadk v0.2.0/go.mod h1:blDAd6sIyExkjtPP1Q52mUXHNJCfkRyWaNPtr51977g=
 go.temporal.io/sdk/contrib/opentelemetry v0.7.0 h1:GSna1HP+1ibNXZ9xlVdQU2zFVqdt5VcdF0dzpeaYccQ=
 go.temporal.io/sdk/contrib/opentelemetry v0.7.0/go.mod h1:oQJC6UIl3FbSYh4f2MlUAIYSE6FPw02X1Tw8/bOvfxg=
 go.temporal.io/sdk/contrib/opentracing v0.3.0 h1:IKJgyvZiaOSFl0YHSxJpwXwQa08W3KaZCJkbx05rX7Q=

--- a/googleadk/README.md
+++ b/googleadk/README.md
@@ -11,8 +11,11 @@ and the whole run is replayable.
 Agents are built the native ADK way (`llmagent.New` + `runner.New`); the only
 Temporal-specific pieces are `googleadk.NewModel(...)` as the agent's model,
 `googleadk.NewContext(ctx)` passed to `Run`, and the worker-side
-`googleadk.NewActivities(...)` registry that holds the real Gemini client (so the
-API key stays worker-side, never crossing into the workflow).
+`googleadk.NewPlugin(...)` in `worker.Options.Plugins`, whose config holds the
+real Gemini client (so the API key stays worker-side, never crossing into the
+workflow). The tests register the integration's Activities directly with
+`googleadk.NewActivities(...)` instead, since the test environments run no
+plugins.
 
 Every sample runs against a scripted `FakeModel` in its `*_test.go`, so
 `go test ./googleadk/...` needs no API key or network.

--- a/googleadk/chat/worker/main.go
+++ b/googleadk/chat/worker/main.go
@@ -24,12 +24,9 @@ func main() {
 	}
 	defer c.Close()
 
-	w := worker.New(c, chat.TaskQueue, worker.Options{})
-
-	w.RegisterWorkflow(chat.ChatWorkflow)
-	// The chat agent has no tools, so only the model Activity is registered.
-
-	acts, err := googleadk.NewActivities(googleadk.Config{
+	// The plugin registers the integration's model Activity on the worker. The
+	// chat agent has no tools, so that is the only registration it brings.
+	adkPlugin, err := googleadk.NewPlugin(googleadk.Config{
 		Models: map[string]googleadk.ModelFactory{
 			chat.ModelName: func(ctx context.Context, name string) (model.LLM, error) {
 				// nil config reads GEMINI_API_KEY / GOOGLE_API_KEY from the env.
@@ -38,9 +35,14 @@ func main() {
 		},
 	})
 	if err != nil {
-		log.Fatalln("Unable to build googleadk activities", err)
+		log.Fatalln("Unable to build googleadk plugin", err)
 	}
-	acts.Register(w)
+
+	w := worker.New(c, chat.TaskQueue, worker.Options{
+		Plugins: []worker.Plugin{adkPlugin},
+	})
+
+	w.RegisterWorkflow(chat.ChatWorkflow)
 
 	if err := w.Run(worker.InterruptCh()); err != nil {
 		log.Fatalln("Unable to start worker", err)

--- a/googleadk/humanintheloop/worker/main.go
+++ b/googleadk/humanintheloop/worker/main.go
@@ -24,14 +24,10 @@ func main() {
 	}
 	defer c.Close()
 
-	w := worker.New(c, humanintheloop.TaskQueue, worker.Options{})
-
-	w.RegisterWorkflow(humanintheloop.ApprovalWorkflow)
-	// The delete_resource tool is an in-workflow function tool (not an
-	// ActivityAsTool), so there is no tool activity to register here — only the
-	// model Activity below.
-
-	acts, err := googleadk.NewActivities(googleadk.Config{
+	// The plugin registers the integration's model Activity on the worker. The
+	// delete_resource tool is an in-workflow function tool (not an
+	// ActivityAsTool), so there is no tool activity to register.
+	adkPlugin, err := googleadk.NewPlugin(googleadk.Config{
 		Models: map[string]googleadk.ModelFactory{
 			humanintheloop.ModelName: func(ctx context.Context, name string) (model.LLM, error) {
 				// nil config reads GEMINI_API_KEY / GOOGLE_API_KEY from the env.
@@ -40,9 +36,14 @@ func main() {
 		},
 	})
 	if err != nil {
-		log.Fatalln("Unable to build googleadk activities", err)
+		log.Fatalln("Unable to build googleadk plugin", err)
 	}
-	acts.Register(w)
+
+	w := worker.New(c, humanintheloop.TaskQueue, worker.Options{
+		Plugins: []worker.Plugin{adkPlugin},
+	})
+
+	w.RegisterWorkflow(humanintheloop.ApprovalWorkflow)
 
 	if err := w.Run(worker.InterruptCh()); err != nil {
 		log.Fatalln("Unable to start worker", err)

--- a/googleadk/multiagent/worker/main.go
+++ b/googleadk/multiagent/worker/main.go
@@ -25,22 +25,15 @@ func main() {
 	}
 	defer c.Close()
 
-	w := worker.New(c, multiagent.TaskQueue, worker.Options{})
-
-	w.RegisterWorkflow(multiagent.MultiAgentWorkflow)
-	// Register GetWeather under the tool name the ActivityAsTool dispatches, so the
-	// weather specialist's get_weather call resolves to this activity.
-	w.RegisterActivityWithOptions(multiagent.GetWeather, activity.RegisterOptions{Name: multiagent.WeatherToolName})
-
-	// Register the integration's model Activity. Every agent in the tree uses a
-	// distinct model name so they can be scripted independently in tests; here
-	// they all resolve to the same real Gemini model. The API key is read
-	// worker-side and never crosses into the workflow.
+	// The plugin registers the integration's model Activity on the worker. Every
+	// agent in the tree uses a distinct model name so they can be scripted
+	// independently in tests; here they all resolve to the same real Gemini
+	// model. The API key is read worker-side and never crosses into the workflow.
 	gemModel := func(ctx context.Context, name string) (model.LLM, error) {
 		// nil config reads GEMINI_API_KEY / GOOGLE_API_KEY from the env.
 		return gemini.NewModel(ctx, "gemini-2.0-flash", nil)
 	}
-	acts, err := googleadk.NewActivities(googleadk.Config{
+	adkPlugin, err := googleadk.NewPlugin(googleadk.Config{
 		Models: map[string]googleadk.ModelFactory{
 			multiagent.CoordinatorModelName: gemModel,
 			multiagent.WeatherModelName:     gemModel,
@@ -48,9 +41,17 @@ func main() {
 		},
 	})
 	if err != nil {
-		log.Fatalln("Unable to build googleadk activities", err)
+		log.Fatalln("Unable to build googleadk plugin", err)
 	}
-	acts.Register(w)
+
+	w := worker.New(c, multiagent.TaskQueue, worker.Options{
+		Plugins: []worker.Plugin{adkPlugin},
+	})
+
+	w.RegisterWorkflow(multiagent.MultiAgentWorkflow)
+	// Register GetWeather under the tool name the ActivityAsTool dispatches, so the
+	// weather specialist's get_weather call resolves to this activity.
+	w.RegisterActivityWithOptions(multiagent.GetWeather, activity.RegisterOptions{Name: multiagent.WeatherToolName})
 
 	if err := w.Run(worker.InterruptCh()); err != nil {
 		log.Fatalln("Unable to start worker", err)

--- a/googleadk/worker/main.go
+++ b/googleadk/worker/main.go
@@ -26,18 +26,12 @@ func main() {
 	defer c.Close()
 
 	// @@@SNIPSTART googleadk-hello-worker
-	w := worker.New(c, adk.TaskQueue, worker.Options{})
-
-	w.RegisterWorkflow(adk.AgentWorkflow)
-	// Register GetWeather under the tool name the ActivityAsTool dispatches, so the
-	// agent's get_weather call resolves to this activity.
-	w.RegisterActivityWithOptions(adk.GetWeather, activity.RegisterOptions{Name: adk.WeatherToolName})
-
-	// Register the integration's model Activity. The real Gemini model lives here,
-	// behind the Activity boundary; the API key is read worker-side from the env
-	// and never crosses into the workflow. Disable the model SDK's own retries so
-	// Temporal's RetryPolicy is the single source of truth.
-	acts, err := googleadk.NewActivities(googleadk.Config{
+	// The plugin registers the integration's Activities on the worker (and closes
+	// any cached MCP toolsets at worker stop). The real Gemini model lives in the
+	// factory, behind the Activity boundary; the API key is read worker-side from
+	// the env and never crosses into the workflow. Disable the model SDK's own
+	// retries so Temporal's RetryPolicy is the single source of truth.
+	adkPlugin, err := googleadk.NewPlugin(googleadk.Config{
 		Models: map[string]googleadk.ModelFactory{
 			adk.ModelName: func(ctx context.Context, name string) (model.LLM, error) {
 				// nil config reads GEMINI_API_KEY / GOOGLE_API_KEY from the env.
@@ -46,9 +40,17 @@ func main() {
 		},
 	})
 	if err != nil {
-		log.Fatalln("Unable to build googleadk activities", err)
+		log.Fatalln("Unable to build googleadk plugin", err)
 	}
-	acts.Register(w)
+
+	w := worker.New(c, adk.TaskQueue, worker.Options{
+		Plugins: []worker.Plugin{adkPlugin},
+	})
+
+	w.RegisterWorkflow(adk.AgentWorkflow)
+	// Register GetWeather under the tool name the ActivityAsTool dispatches, so the
+	// agent's get_weather call resolves to this activity.
+	w.RegisterActivityWithOptions(adk.GetWeather, activity.RegisterOptions{Name: adk.WeatherToolName})
 
 	if err := w.Run(worker.InterruptCh()); err != nil {
 		log.Fatalln("Unable to start worker", err)


### PR DESCRIPTION
## What

Switches the four `googleadk/` sample workers from `NewActivities` + `acts.Register(w)` to the integration's plugin — the standard wiring as of [`contrib/googleadk` v0.2.0](https://github.com/temporalio/sdk-go/releases/tag/contrib%2Fgoogleadk%2Fv0.2.0) (temporalio/sdk-go#2478):

```go
adkPlugin, err := googleadk.NewPlugin(googleadk.Config{Models: ...})
w := worker.New(c, taskQueue, worker.Options{Plugins: []worker.Plugin{adkPlugin}})
```

Besides matching the Python SDK's `GoogleAdkPlugin` shape, the plugin closes cached MCP toolsets at worker stop automatically. The sample tests keep registering the Activities directly (`NewActivities` + `Register`) because the test environments construct no real worker and therefore run no plugins (temporalio/sdk-go#2480 tracks lifting that) — the root README explains the split.

`go.mod` pins the released `go.temporal.io/sdk/contrib/googleadk v0.2.0`.

## Testing

All googleadk sample tests pass against v0.2.0; full build + vet + workflowcheck clean.
