### PR TITLE
Add snipsync markers to the helloworld Worker

### DIFF
--- a/helloworld/worker/main.go
+++ b/helloworld/worker/main.go
@@ -1,3 +1,4 @@
+// @@@SNIPSTART go-create-worker
 package main
 
 import (
@@ -28,3 +29,4 @@ func main() {
 		log.Fatalln("Unable to start worker", err)
 	}
 }
+// @@@SNIPEND


### PR DESCRIPTION
## What

Wraps `helloworld/worker/main.go` in snipsync markers as `go-create-worker`. Comment-only change, two lines.

## Why

The Go SDK **Run a Worker** docs page currently duplicates this Worker setup as hand-written inline code. Marking the sample lets the page pull from here instead, so the docs stay in sync with a sample that actually compiles and runs.

This mirrors what `lambda-worker/worker/main.go` already does for the Serverless Workers page, and uses the same marker placement (before `package main`, immediately after the closing brace).

## Verification

`go build ./helloworld/...` passes.