### PR TITLE
Nexus Per Endpoint Encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ These samples demonstrate some common control flow patterns using Temporal's Go 
 
 - [**Nexus Context Propagation**](./nexus-context-propagation): Demonstrates how to propagate context through client calls, workflows, and Nexus headers.
 
+- [**Nexus Per-Endpoint Encryption**](./nexus-per-endpoint-encryption): Demonstrates context-aware encryption with a different key for each Nexus endpoint.
+
 
 
 ### Scenario based examples

--- a/nexus-per-endpoint-encryption/README.md
+++ b/nexus-per-endpoint-encryption/README.md
@@ -1,0 +1,88 @@
+# Nexus per-endpoint encryption
+
+This sample extends the [getting started Nexus sample](../nexus) with a context-aware payload codec. The codec uses
+`converter.NexusSerializationContext.Endpoint` to select a different AES-GCM key for each Nexus endpoint.
+The serialization context also identifies the Nexus service and operation, so a codec can instead select keys by
+service, by operation, or by any combination of endpoint, service, and operation.
+
+Per-endpoint key selection has an important limitation for workflow-backed operations. Multiple Nexus operations can
+attach completion callbacks to the same workflow execution, including operations invoked through different endpoints.
+Because that workflow execution produces one serialized result shared by all attached operations, the result cannot be
+encrypted separately with a different key for each endpoint. Applications using this pattern must ensure that every
+operation attached to the same workflow execution resolves to the same key (or avoid attaching operations from
+different key domains to that execution). Application that must should use a wrapper workflow to decouple the results.
+
+
+The caller workflow starts four Nexus operations before waiting for their results:
+
+- a synchronous operation through `nexus-encryption-endpoint-a`
+- a workflow-backed asynchronous operation through `nexus-encryption-endpoint-a`
+- a synchronous operation through `nexus-encryption-endpoint-b`
+- a workflow-backed asynchronous operation through `nexus-encryption-endpoint-b`
+
+Ordinary workflow payloads are left unchanged. Nexus operation inputs and outputs, including the asynchronous handler
+workflow input and result, are encrypted with the key assigned to the endpoint.
+
+This sample uses unreleased Go SDK support for `converter.NexusSerializationContext`. While developing it alongside a
+checkout of `sdk-go`, create a local workspace from the `samples-go` directory:
+
+```shell
+go work init .
+go work use ../sdk-go
+```
+
+The workspace file is only needed until `samples-go` depends on an SDK release containing the feature.
+
+## Run the sample
+
+Start a local Temporal server:
+
+```shell
+temporal server start-dev
+```
+
+Create the caller and handler namespaces:
+
+```shell
+temporal operator namespace create --namespace nexus-encryption-caller
+temporal operator namespace create --namespace nexus-encryption-handler
+```
+
+Create two endpoints that route to the same handler worker:
+
+```shell
+temporal operator nexus endpoint create \
+  --name nexus-encryption-endpoint-a \
+  --target-namespace nexus-encryption-handler \
+  --target-task-queue nexus-encryption-handler-task-queue
+
+temporal operator nexus endpoint create \
+  --name nexus-encryption-endpoint-b \
+  --target-namespace nexus-encryption-handler \
+  --target-task-queue nexus-encryption-handler-task-queue
+```
+
+Run the handler and caller workers in separate terminals:
+
+```shell
+go run ./nexus-per-endpoint-encryption/handler/worker \
+  -target-host localhost:7233 \
+  -namespace nexus-encryption-handler
+```
+
+```shell
+go run ./nexus-per-endpoint-encryption/caller/worker \
+  -target-host localhost:7233 \
+  -namespace nexus-encryption-caller
+```
+
+Start the caller workflow:
+
+```shell
+go run ./nexus-per-endpoint-encryption/caller/starter \
+  -target-host localhost:7233 \
+  -namespace nexus-encryption-caller
+```
+
+The endpoint keys in this sample are hard-coded for clarity. Production applications should load keys from a secure
+key-management system and use stable key identifiers to support rotation.

--- a/nexus-per-endpoint-encryption/caller/starter/main.go
+++ b/nexus-per-endpoint-encryption/caller/starter/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+
+	"go.temporal.io/sdk/client"
+
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/caller"
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/encryption"
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/service"
+	"github.com/temporalio/samples-go/nexus/options"
+)
+
+func main() {
+	clientOptions, err := options.ParseClientOptionFlags(os.Args[1:])
+	if err != nil {
+		log.Fatalf("Invalid arguments: %v", err)
+	}
+	clientOptions.DataConverter = encryption.NewDataConverter()
+	c, err := client.Dial(clientOptions)
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	run, err := c.ExecuteWorkflow(context.Background(), client.StartWorkflowOptions{
+		ID:        "nexus-per-endpoint-encryption-" + time.Now().Format("20060102150405"),
+		TaskQueue: caller.TaskQueue,
+	}, caller.PerEndpointEncryptionWorkflow)
+	if err != nil {
+		log.Fatalln("Unable to start workflow", err)
+	}
+
+	var result service.WorkflowOutput
+	if err := run.Get(context.Background(), &result); err != nil {
+		log.Fatalln("Unable to get workflow result", err)
+	}
+	log.Printf("Workflow result: %+v", result)
+}

--- a/nexus-per-endpoint-encryption/caller/worker/main.go
+++ b/nexus-per-endpoint-encryption/caller/worker/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/caller"
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/encryption"
+	"github.com/temporalio/samples-go/nexus/options"
+)
+
+func main() {
+	clientOptions, err := options.ParseClientOptionFlags(os.Args[1:])
+	if err != nil {
+		log.Fatalf("Invalid arguments: %v", err)
+	}
+	clientOptions.DataConverter = encryption.NewDataConverter()
+	c, err := client.Dial(clientOptions)
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	w := worker.New(c, caller.TaskQueue, worker.Options{})
+	w.RegisterWorkflow(caller.PerEndpointEncryptionWorkflow)
+	if err := w.Run(worker.InterruptCh()); err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+}

--- a/nexus-per-endpoint-encryption/caller/workflow.go
+++ b/nexus-per-endpoint-encryption/caller/workflow.go
@@ -1,0 +1,63 @@
+package caller
+
+import (
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/service"
+)
+
+const TaskQueue = "nexus-encryption-caller-task-queue"
+
+func PerEndpointEncryptionWorkflow(ctx workflow.Context) (service.WorkflowOutput, error) {
+	endpointA := workflow.NewNexusClient(service.EndpointA, service.Name)
+	endpointB := workflow.NewNexusClient(service.EndpointB, service.Name)
+	workflowID := workflow.GetInfo(ctx).WorkflowExecution.ID
+
+	endpointASync := endpointA.ExecuteOperation(
+		ctx,
+		service.SyncOperationName,
+		service.OperationInput{Message: "endpoint A", RequestID: workflowID + "-endpoint-a-sync"},
+		workflow.NexusOperationOptions{},
+	)
+	endpointAAsync := endpointA.ExecuteOperation(
+		ctx,
+		service.AsyncOperationName,
+		service.OperationInput{Message: "endpoint A", RequestID: workflowID + "-endpoint-a-async"},
+		workflow.NexusOperationOptions{},
+	)
+	endpointBSync := endpointB.ExecuteOperation(
+		ctx,
+		service.SyncOperationName,
+		service.OperationInput{Message: "endpoint B", RequestID: workflowID + "-endpoint-b-sync"},
+		workflow.NexusOperationOptions{},
+	)
+	endpointBAsync := endpointB.ExecuteOperation(
+		ctx,
+		service.AsyncOperationName,
+		service.OperationInput{Message: "endpoint B", RequestID: workflowID + "-endpoint-b-async"},
+		workflow.NexusOperationOptions{},
+	)
+
+	var endpointASyncResult service.OperationOutput
+	if err := endpointASync.Get(ctx, &endpointASyncResult); err != nil {
+		return service.WorkflowOutput{}, err
+	}
+	var endpointAAsyncResult service.OperationOutput
+	if err := endpointAAsync.Get(ctx, &endpointAAsyncResult); err != nil {
+		return service.WorkflowOutput{}, err
+	}
+	var endpointBSyncResult service.OperationOutput
+	if err := endpointBSync.Get(ctx, &endpointBSyncResult); err != nil {
+		return service.WorkflowOutput{}, err
+	}
+	var endpointBAsyncResult service.OperationOutput
+	if err := endpointBAsync.Get(ctx, &endpointBAsyncResult); err != nil {
+		return service.WorkflowOutput{}, err
+	}
+	return service.WorkflowOutput{
+		EndpointASync:  endpointASyncResult.Message,
+		EndpointAAsync: endpointAAsyncResult.Message,
+		EndpointBSync:  endpointBSyncResult.Message,
+		EndpointBAsync: endpointBAsyncResult.Message,
+	}, nil
+}

--- a/nexus-per-endpoint-encryption/caller/workflow_test.go
+++ b/nexus-per-endpoint-encryption/caller/workflow_test.go
@@ -1,0 +1,39 @@
+package caller_test
+
+import (
+	"testing"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
+
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/caller"
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/encryption"
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/handler"
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/service"
+)
+
+func TestWorkflowCallsSyncAndAsyncOperationsOnBothEndpoints(t *testing.T) {
+	var testSuite testsuite.WorkflowTestSuite
+	env := testSuite.NewTestWorkflowEnvironment()
+	env.SetDataConverter(encryption.NewDataConverter())
+	env.RegisterWorkflow(caller.PerEndpointEncryptionWorkflow)
+	env.RegisterWorkflow(handler.AsyncOperationWorkflow)
+
+	nexusService := nexus.NewService(service.Name)
+	require.NoError(t, nexusService.Register(handler.SyncOperation, handler.AsyncOperation))
+	env.RegisterNexusService(nexusService)
+
+	env.ExecuteWorkflow(caller.PerEndpointEncryptionWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	var result service.WorkflowOutput
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.Equal(t, service.WorkflowOutput{
+		EndpointASync:  "sync: endpoint A",
+		EndpointAAsync: "async: endpoint A",
+		EndpointBSync:  "sync: endpoint B",
+		EndpointBAsync: "async: endpoint B",
+	}, result)
+}

--- a/nexus-per-endpoint-encryption/encryption/codec.go
+++ b/nexus-per-endpoint-encryption/encryption/codec.go
@@ -1,0 +1,117 @@
+package encryption
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/converter"
+
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/service"
+)
+
+const metadataEncodingEncrypted = "binary/encrypted"
+
+var endpointKeys = map[string][]byte{
+	service.EndpointA: []byte("endpoint-a-key-32-bytes-long!!!!"),
+	service.EndpointB: []byte("endpoint-b-key-32-bytes-long!!!!"),
+}
+
+type Codec struct {
+	endpoint string
+}
+
+func (c *Codec) WithSerializationContext(ctx converter.SerializationContext) converter.PayloadCodec {
+	nexusCtx, ok := ctx.(converter.NexusSerializationContext)
+	if !ok {
+		return &Codec{}
+	}
+	return &Codec{endpoint: nexusCtx.Endpoint}
+}
+
+func (c *Codec) Encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	if c.endpoint == "" {
+		return payloads, nil
+	}
+	gcm, err := c.gcm()
+	if err != nil {
+		return nil, err
+	}
+
+	encoded := make([]*commonpb.Payload, len(payloads))
+	for i, payload := range payloads {
+		plainText, err := payload.Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("marshal payload: %w", err)
+		}
+		nonce := make([]byte, gcm.NonceSize())
+		if _, err := rand.Read(nonce); err != nil {
+			return nil, fmt.Errorf("generate nonce: %w", err)
+		}
+		cipherText := gcm.Seal(nonce, nonce, plainText, []byte(c.endpoint))
+		encoded[i] = &commonpb.Payload{
+			Metadata: map[string][]byte{
+				converter.MetadataEncoding: []byte(metadataEncodingEncrypted),
+				"endpoint":                 []byte(c.endpoint),
+			},
+			Data: cipherText,
+		}
+	}
+	return encoded, nil
+}
+
+func (c *Codec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) {
+	decoded := make([]*commonpb.Payload, len(payloads))
+	for i, payload := range payloads {
+		if !bytes.Equal(payload.Metadata[converter.MetadataEncoding], []byte(metadataEncodingEncrypted)) {
+			decoded[i] = payload
+			continue
+		}
+		if c.endpoint == "" {
+			return nil, fmt.Errorf("encrypted Nexus payload is missing serialization context")
+		}
+		if payloadEndpoint := string(payload.Metadata["endpoint"]); payloadEndpoint != c.endpoint {
+			return nil, fmt.Errorf("payload endpoint %q does not match serialization context endpoint %q", payloadEndpoint, c.endpoint)
+		}
+		gcm, err := c.gcm()
+		if err != nil {
+			return nil, err
+		}
+		if len(payload.Data) < gcm.NonceSize() {
+			return nil, fmt.Errorf("encrypted payload is shorter than its nonce")
+		}
+		nonce, cipherText := payload.Data[:gcm.NonceSize()], payload.Data[gcm.NonceSize():]
+		plainText, err := gcm.Open(nil, nonce, cipherText, []byte(c.endpoint))
+		if err != nil {
+			return nil, fmt.Errorf("decrypt payload for endpoint %q: %w", c.endpoint, err)
+		}
+		decoded[i] = &commonpb.Payload{}
+		if err := decoded[i].Unmarshal(plainText); err != nil {
+			return nil, fmt.Errorf("unmarshal payload: %w", err)
+		}
+	}
+	return decoded, nil
+}
+
+func (c *Codec) gcm() (cipher.AEAD, error) {
+	key, ok := endpointKeys[c.endpoint]
+	if !ok {
+		return nil, fmt.Errorf("no encryption key configured for Nexus endpoint %q", c.endpoint)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("create AES cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create AES-GCM cipher: %w", err)
+	}
+	return gcm, nil
+}
+
+func NewDataConverter() converter.DataConverter {
+	return converter.NewCodecDataConverter(converter.GetDefaultDataConverter(), &Codec{})
+}

--- a/nexus-per-endpoint-encryption/encryption/codec_test.go
+++ b/nexus-per-endpoint-encryption/encryption/codec_test.go
@@ -1,0 +1,46 @@
+package encryption
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/converter"
+
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/service"
+)
+
+func TestCodecUsesDifferentKeysForEachEndpoint(t *testing.T) {
+	require.NotEqual(t, endpointKeys[service.EndpointA], endpointKeys[service.EndpointB])
+
+	dataConverter := NewDataConverter()
+	endpointAConverter := converter.WithDataConverterSerializationContext(
+		dataConverter,
+		converter.NexusSerializationContext{Endpoint: service.EndpointA},
+	)
+	endpointBConverter := converter.WithDataConverterSerializationContext(
+		dataConverter,
+		converter.NexusSerializationContext{Endpoint: service.EndpointB},
+	)
+
+	endpointAPayload, err := endpointAConverter.ToPayload("secret")
+	require.NoError(t, err)
+	endpointBPayload, err := endpointBConverter.ToPayload("secret")
+	require.NoError(t, err)
+	require.NotEqual(t, endpointAPayload.Data, endpointBPayload.Data)
+
+	var value string
+	require.NoError(t, endpointAConverter.FromPayload(endpointAPayload, &value))
+	require.Equal(t, "secret", value)
+	require.Error(t, endpointBConverter.FromPayload(endpointAPayload, &value))
+}
+
+func TestCodecLeavesNonNexusPayloadsUnchanged(t *testing.T) {
+	dataConverter := converter.WithDataConverterSerializationContext(
+		NewDataConverter(),
+		converter.WorkflowSerializationContext{Namespace: "namespace", WorkflowID: "workflow-id"},
+	)
+
+	payload, err := dataConverter.ToPayload("plain")
+	require.NoError(t, err)
+	require.NotEqual(t, metadataEncodingEncrypted, string(payload.Metadata[converter.MetadataEncoding]))
+}

--- a/nexus-per-endpoint-encryption/handler/app.go
+++ b/nexus-per-endpoint-encryption/handler/app.go
@@ -1,0 +1,31 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporalnexus"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/service"
+)
+
+var SyncOperation = nexus.NewSyncOperation(
+	service.SyncOperationName,
+	func(_ context.Context, input service.OperationInput, _ nexus.StartOperationOptions) (service.OperationOutput, error) {
+		return service.OperationOutput{Message: "sync: " + input.Message}, nil
+	},
+)
+
+var AsyncOperation = temporalnexus.NewWorkflowRunOperation(
+	service.AsyncOperationName,
+	AsyncOperationWorkflow,
+	func(_ context.Context, input service.OperationInput, _ nexus.StartOperationOptions) (client.StartWorkflowOptions, error) {
+		return client.StartWorkflowOptions{ID: "encrypted-operation-" + input.RequestID}, nil
+	},
+)
+
+func AsyncOperationWorkflow(_ workflow.Context, input service.OperationInput) (service.OperationOutput, error) {
+	return service.OperationOutput{Message: "async: " + input.Message}, nil
+}

--- a/nexus-per-endpoint-encryption/handler/worker/main.go
+++ b/nexus-per-endpoint-encryption/handler/worker/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/encryption"
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/handler"
+	"github.com/temporalio/samples-go/nexus-per-endpoint-encryption/service"
+	"github.com/temporalio/samples-go/nexus/options"
+)
+
+const taskQueue = "nexus-encryption-handler-task-queue"
+
+func main() {
+	clientOptions, err := options.ParseClientOptionFlags(os.Args[1:])
+	if err != nil {
+		log.Fatalf("Invalid arguments: %v", err)
+	}
+	clientOptions.DataConverter = encryption.NewDataConverter()
+	c, err := client.Dial(clientOptions)
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	nexusService := nexus.NewService(service.Name)
+	if err := nexusService.Register(handler.SyncOperation, handler.AsyncOperation); err != nil {
+		log.Fatalln("Unable to register Nexus operations", err)
+	}
+
+	w := worker.New(c, taskQueue, worker.Options{})
+	w.RegisterNexusService(nexusService)
+	w.RegisterWorkflow(handler.AsyncOperationWorkflow)
+	if err := w.Run(worker.InterruptCh()); err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+}

--- a/nexus-per-endpoint-encryption/service/api.go
+++ b/nexus-per-endpoint-encryption/service/api.go
@@ -1,0 +1,27 @@
+package service
+
+const (
+	Name = "per-endpoint-encryption-service"
+
+	EndpointA = "nexus-encryption-endpoint-a"
+	EndpointB = "nexus-encryption-endpoint-b"
+
+	SyncOperationName  = "encrypted-echo"
+	AsyncOperationName = "encrypted-workflow"
+)
+
+type OperationInput struct {
+	Message   string
+	RequestID string
+}
+
+type OperationOutput struct {
+	Message string
+}
+
+type WorkflowOutput struct {
+	EndpointASync  string
+	EndpointAAsync string
+	EndpointBSync  string
+	EndpointBAsync string
+}


### PR DESCRIPTION
 ## What was changed

  Added a Nexus encryption sample demonstrating how to use NexusSerializationContext to select an AES-GCM encryption key based on the Nexus endpoint handling an operation. The same context can also support key selection by service, operation, or a combination of those values.

The sample includes synchronous and workflow-backed asynchronous operations across two endpoints, along with tests and setup instructions. It also documents the limitation that operations attached to the same workflow execution share one serialized result and therefore must resolve to the same encryption key.

## Why?

Context-aware serialization lets applications protect Nexus payloads according to where they are sent. For example, services can isolate payloads across endpoints, services, operations, tenants, or security domains without creating separate data-converter implementations for each one.

This sample gives users a practical reference for implementing that pattern safely, including guidance for workflow executions shared by multiple attached Nexus operations.

