### PR TITLE
Add Cloud Run worker OpenTelemetry sample

### DIFF
--- a/cloud-run-worker/Dockerfile
+++ b/cloud-run-worker/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.25-bookworm AS build
+
+WORKDIR /src
+COPY . .
+RUN go build -trimpath -ldflags="-s -w" -o /out/cloud-run-worker ./cloud-run-worker/worker
+
+FROM gcr.io/distroless/base-debian12:nonroot
+COPY --from=build /out/cloud-run-worker /cloud-run-worker
+ENTRYPOINT ["/cloud-run-worker"]

--- a/cloud-run-worker/README.md
+++ b/cloud-run-worker/README.md
@@ -1,0 +1,109 @@
+# Cloud Run Worker
+
+This sample demonstrates how to run a long-running Temporal Worker on
+[Google Cloud Run](https://cloud.google.com/run) using the
+[`cloudrun`](https://pkg.go.dev/go.temporal.io/sdk/contrib/gcp/cloudrun) contrib
+package. It includes OpenTelemetry instrumentation that exports traces and
+metrics through a Google-Built OpenTelemetry Collector sidecar to Google Cloud
+(Cloud Trace and Google Managed Service for Prometheus).
+
+Cloud Run **worker pools** are the recommended deployment because Temporal
+workers are continuous, pull-based background workloads with no request ingress.
+
+The sample registers a simple greeting Workflow and Activity, but the pattern
+applies to any Workflow/Activity definitions.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `worker/main.go` | Long-running worker entry point -- creates the plugin, dials Temporal, registers Workflows/Activities, and shuts down gracefully on SIGTERM |
+| `starter/main.go` | Helper program to start a Workflow execution against the worker |
+| `greeting/workflow.go` | Sample Workflow that executes a greeting Activity |
+| `greeting/activity.go` | Sample Activity that returns a greeting string |
+| `otel-collector-config.yaml` | Google-Built OpenTelemetry Collector sidecar configuration (metrics without batch, traces with batch, GCP resource detection) |
+| `worker-pool.yaml` | Cloud Run worker pool manifest with the worker and collector sidecar, a startup probe, and container dependencies |
+| `Dockerfile` | Builds the worker container image |
+| `cloudbuild.yaml` | Cloud Build config that builds and pushes the image |
+
+## Prerequisites
+
+- A [Temporal Cloud](https://temporal.io/cloud) namespace (or a self-hosted
+  Temporal cluster reachable from Cloud Run)
+- The `gcloud` CLI configured for a project with Cloud Run, Cloud Build, Cloud
+  Trace, and Monitoring APIs enabled
+- Go 1.25+
+
+## Configure the Temporal connection
+
+The worker and starter load their connection from the environment via
+[`envconfig`](https://pkg.go.dev/go.temporal.io/sdk/contrib/envconfig). Set the
+standard `TEMPORAL_ADDRESS`, `TEMPORAL_NAMESPACE`, and `TEMPORAL_API_KEY`
+environment variables (or a `temporal.toml`) before running.
+
+## Run locally
+
+Start the worker (it will export OTLP telemetry to `localhost:4317`; run a local
+collector there if you want to see it, otherwise the export is a no-op):
+
+```bash
+cd cloud-run-worker
+go run ./worker
+```
+
+In another terminal, start a workflow:
+
+```bash
+cd cloud-run-worker
+go run ./starter
+```
+
+> **Note on the temporary module replace:** `go.temporal.io/sdk/contrib/gcp/cloudrun`
+> is not yet published, so `samples-go/go.mod` contains a local
+> `replace go.temporal.io/sdk/contrib/gcp/cloudrun => ../sdk-go/contrib/gcp/cloudrun`.
+> This makes `go run`/`go build` work against the in-repo module, but a container
+> build (whose build context is the samples repo) cannot reach `../sdk-go`. Remove
+> the replace once the module is published; until then, build the image from a
+> checkout that vendors or otherwise provides the module.
+
+## Deploy to a Cloud Run worker pool
+
+1. Build and push the worker image with Cloud Build:
+
+   ```bash
+   gcloud builds submit --config=cloud-run-worker/cloudbuild.yaml \
+     --substitutions=_IMAGE=<REGION>-docker.pkg.dev/<PROJECT>/<REPO>/cloud-run-worker:latest .
+   ```
+
+2. Store the collector config and Temporal API key in Secret Manager:
+
+   ```bash
+   gcloud secrets create otel-collector-config --data-file=cloud-run-worker/otel-collector-config.yaml
+   printf '%s' "<your-temporal-api-key>" | gcloud secrets create temporal-api-key --data-file=-
+   ```
+
+3. Edit `worker-pool.yaml` (image, region, Temporal connection) and deploy:
+
+   ```bash
+   gcloud beta run worker-pools replace cloud-run-worker/worker-pool.yaml --region=<REGION>
+   ```
+
+The worker pool runs the worker alongside the Google-Built OpenTelemetry
+Collector sidecar. The worker's `dependsOn` on the collector and the collector's
+health-check startup probe ensure the collector is ready before the worker
+starts emitting telemetry.
+
+## Shutdown lifecycle
+
+Cloud Run sends `SIGTERM` and allows roughly ten seconds before `SIGKILL`. On
+that signal the worker stops polling, closes the Temporal client, and calls
+`plugin.Shutdown` with an eight-second deadline to flush buffered metrics and
+traces before the process exits.
+
+## Telemetry pipeline
+
+Metrics are sent to `googlemanagedprometheus` **without** a collector `batch`
+processor: batching can merge periodic and forced-shutdown snapshots of the same
+cumulative series into one Google Monitoring write, which is rejected as
+duplicate data. Traces are sent to `googlecloud` and may be batched
+independently. The plugin exports metrics every 60 seconds by default.

--- a/cloud-run-worker/cloudbuild.yaml
+++ b/cloud-run-worker/cloudbuild.yaml
@@ -1,0 +1,9 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - --file=cloud-run-worker/Dockerfile
+      - --tag=${_IMAGE}
+      - .
+images:
+  - ${_IMAGE}

--- a/cloud-run-worker/greeting/activity.go
+++ b/cloud-run-worker/greeting/activity.go
@@ -1,0 +1,11 @@
+package greeting
+
+import (
+	"context"
+	"fmt"
+)
+
+// HelloActivity is a basic activity function.
+func HelloActivity(ctx context.Context, name string) (string, error) {
+	return fmt.Sprintf("Hello, %s!", name), nil
+}

--- a/cloud-run-worker/greeting/workflow.go
+++ b/cloud-run-worker/greeting/workflow.go
@@ -1,0 +1,28 @@
+package greeting
+
+import (
+	"time"
+
+	"go.temporal.io/sdk/workflow"
+)
+
+// SampleWorkflow is a basic workflow definition.
+func SampleWorkflow(ctx workflow.Context, name string) (string, error) {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("SampleWorkflow started", "name", name)
+
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: 10 * time.Second,
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	var result string
+	err := workflow.ExecuteActivity(ctx, HelloActivity, name).Get(ctx, &result)
+	if err != nil {
+		logger.Error("Activity failed", "error", err)
+		return "", err
+	}
+
+	logger.Info("SampleWorkflow completed", "result", result)
+	return result, nil
+}

--- a/cloud-run-worker/otel-collector-config.yaml
+++ b/cloud-run-worker/otel-collector-config.yaml
@@ -34,9 +34,10 @@ exporters:
     googlecloud:
 
 extensions:
-    # Health check used as the container startup probe.
+    # Health check used as the container startup probe. Bind on all interfaces
+    # so the Cloud Run startup probe can reach it.
     health_check:
-        endpoint: localhost:13133
+        endpoint: 0.0.0.0:13133
 
 service:
     extensions: [health_check]

--- a/cloud-run-worker/otel-collector-config.yaml
+++ b/cloud-run-worker/otel-collector-config.yaml
@@ -1,0 +1,56 @@
+# @@@SNIPSTART go-cloud-run-worker-otel-collector-config
+# Google-Built OpenTelemetry Collector configuration for a Cloud Run worker pool
+# sidecar. The Temporal worker exports OTLP gRPC to localhost:4317; this collector
+# adds GCP resource attributes and exports to Google Cloud.
+#
+# Metrics use googlemanagedprometheus with NO batch processor: batching can merge
+# periodic and forced-shutdown snapshots of the same cumulative series into a
+# single Google Monitoring write, which Managed Service for Prometheus rejects as
+# duplicate data. Traces may be batched independently.
+receivers:
+    otlp:
+        protocols:
+            grpc:
+                endpoint: localhost:4317
+
+processors:
+    # Guard the sidecar against unbounded memory growth.
+    memory_limiter:
+        check_interval: 1s
+        limit_percentage: 65
+        spike_limit_percentage: 20
+    # Detect Google Cloud resource attributes (project, region, revision, ...).
+    resourcedetection:
+        detectors: [gcp]
+        timeout: 10s
+    # Batch is used ONLY for traces.
+    batch:
+        send_batch_size: 200
+        timeout: 5s
+
+exporters:
+    debug:
+    googlemanagedprometheus:
+    googlecloud:
+
+extensions:
+    # Health check used as the container startup probe.
+    health_check:
+        endpoint: localhost:13133
+
+service:
+    extensions: [health_check]
+    pipelines:
+        # No batch processor in the metrics pipeline.
+        metrics:
+            receivers: [otlp]
+            processors: [memory_limiter, resourcedetection]
+            exporters: [googlemanagedprometheus, debug]
+        traces:
+            receivers: [otlp]
+            processors: [memory_limiter, resourcedetection, batch]
+            exporters: [googlecloud, debug]
+    telemetry:
+        logs:
+            level: info
+# @@@SNIPEND

--- a/cloud-run-worker/starter/main.go
+++ b/cloud-run-worker/starter/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	greeting "github.com/temporalio/samples-go/cloud-run-worker/greeting"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/contrib/envconfig"
+)
+
+// This is a helper program to start a workflow execution against the Cloud Run worker.
+func main() {
+	c, err := client.Dial(envconfig.MustLoadDefaultClientOptions())
+	if err != nil {
+		log.Fatalln("Unable to create Temporal client", err)
+	}
+	defer c.Close()
+	fmt.Printf("✅ Connected to Temporal Service\n")
+
+	workflowOptions := client.StartWorkflowOptions{
+		ID:        "cloud-run-workflow-id-1",
+		TaskQueue: "cloud-run-task-queue",
+	}
+
+	we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, greeting.SampleWorkflow, "Cloud Run Worker!")
+	if err != nil {
+		log.Fatalln("Unable to execute workflow", err)
+	}
+
+	log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
+
+	var result string
+	err = we.Get(context.Background(), &result)
+	if err != nil {
+		log.Fatalln("Unable to get workflow result", err)
+	}
+
+	log.Println("Workflow result:", result)
+}

--- a/cloud-run-worker/worker-pool.yaml
+++ b/cloud-run-worker/worker-pool.yaml
@@ -1,0 +1,71 @@
+# @@@SNIPSTART go-cloud-run-worker-pool
+# Cloud Run worker pool running the Temporal worker with a Google-Built
+# OpenTelemetry Collector sidecar. Worker pools are the recommended deployment
+# for Temporal workers because they are continuous, pull-based background
+# workloads with no request ingress.
+#
+# Deploy with:
+#   gcloud beta run worker-pools replace worker-pool.yaml --region=<REGION>
+#
+# Replace <PROJECT>, <REGION>, <REPO>, and the Temporal connection values below.
+apiVersion: run.googleapis.com/v1
+kind: WorkerPool
+metadata:
+  name: temporal-cloud-run-worker
+  labels:
+    cloud.googleapis.com/location: <REGION>
+spec:
+  template:
+    metadata:
+      annotations:
+        # Keep at least one instance active so the worker keeps polling.
+        run.googleapis.com/minScale: "1"
+    spec:
+      containers:
+        # Temporal worker. It depends on the collector so telemetry has somewhere
+        # to go as soon as the worker starts.
+        - name: worker
+          image: <REGION>-docker.pkg.dev/<PROJECT>/<REPO>/cloud-run-worker:latest
+          dependsOn:
+            - collector
+          resources:
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          env:
+            - name: TEMPORAL_ADDRESS
+              value: <namespace>.<account>.tmprl.cloud:7233
+            - name: TEMPORAL_NAMESPACE
+              value: <namespace>.<account>
+            # Prefer Secret Manager for the API key in production.
+            - name: TEMPORAL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: temporal-api-key
+                  key: latest
+            # OTEL_EXPORTER_OTLP_ENDPOINT defaults to http://localhost:4317, which
+            # matches the collector sidecar below. CLOUD_RUN_WORKER_POOL supplies
+            # the service.name automatically.
+
+        # Google-Built OpenTelemetry Collector sidecar.
+        - name: collector
+          image: us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:latest
+          args:
+            - --config=/etc/otelcol-google/config.yaml
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133
+            periodSeconds: 5
+            failureThreshold: 12
+          volumeMounts:
+            - name: otel-config
+              mountPath: /etc/otelcol-google
+      volumes:
+        - name: otel-config
+          secret:
+            secretName: otel-collector-config
+            items:
+              - key: latest
+                path: config.yaml
+# @@@SNIPEND

--- a/cloud-run-worker/worker-pool.yaml
+++ b/cloud-run-worker/worker-pool.yaml
@@ -20,14 +20,14 @@ spec:
       annotations:
         # Keep at least one instance active so the worker keeps polling.
         run.googleapis.com/minScale: "1"
+        # Start the collector before the worker so telemetry has somewhere to go.
+        run.googleapis.com/container-dependencies: '{"worker":["collector"]}'
     spec:
       containers:
         # Temporal worker. It depends on the collector so telemetry has somewhere
         # to go as soon as the worker starts.
         - name: worker
           image: <REGION>-docker.pkg.dev/<PROJECT>/<REPO>/cloud-run-worker:latest
-          dependsOn:
-            - collector
           resources:
             limits:
               cpu: "1"

--- a/cloud-run-worker/worker/main.go
+++ b/cloud-run-worker/worker/main.go
@@ -1,0 +1,75 @@
+// @@@SNIPSTART go-cloud-run-worker
+package main
+
+import (
+	"context"
+	"log"
+	"os/signal"
+	"syscall"
+	"time"
+
+	greeting "github.com/temporalio/samples-go/cloud-run-worker/greeting"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/contrib/envconfig"
+	"go.temporal.io/sdk/contrib/gcp/cloudrun"
+	"go.temporal.io/sdk/worker"
+)
+
+const taskQueue = "cloud-run-task-queue"
+
+func main() {
+	ctx := context.Background()
+
+	// The plugin exports OTLP metrics and traces to the collector sidecar on
+	// localhost:4317. The endpoint and service name fall back to environment
+	// variables (OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_SERVICE_NAME,
+	// CLOUD_RUN_WORKER_POOL, K_SERVICE) that Cloud Run provides.
+	otelPlugin, err := cloudrun.NewOpenTelemetryPlugin(ctx, cloudrun.OpenTelemetryPluginOptions{})
+	if err != nil {
+		log.Fatalln("Unable to create OpenTelemetry plugin", err)
+	}
+
+	// Load the Temporal connection from the environment (see temporal.toml or the
+	// TEMPORAL_* environment variables) and install the plugin. Client plugins
+	// that also implement worker.Plugin are applied to workers automatically.
+	clientOptions, err := envconfig.LoadDefaultClientOptions()
+	if err != nil {
+		log.Fatalln("Unable to load Temporal client options", err)
+	}
+	clientOptions.Plugins = append(clientOptions.Plugins, otelPlugin)
+
+	c, err := client.Dial(clientOptions)
+	if err != nil {
+		log.Fatalln("Unable to create Temporal client", err)
+	}
+
+	w := worker.New(c, taskQueue, worker.Options{})
+	w.RegisterWorkflow(greeting.SampleWorkflow)
+	w.RegisterActivity(greeting.HelloActivity)
+
+	if err := w.Start(); err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+	log.Println("Worker started on task queue", taskQueue)
+
+	// Cloud Run sends SIGTERM and allows roughly ten seconds before SIGKILL.
+	signalCtx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	<-signalCtx.Done()
+
+	log.Println("Shutdown signal received, stopping worker")
+	w.Stop()
+	c.Close()
+
+	// Reserve most of Cloud Run's termination window to flush telemetry before
+	// the process is killed.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	if err := otelPlugin.Shutdown(shutdownCtx); err != nil {
+		log.Println("Failed to shut down OpenTelemetry plugin:", err)
+	}
+	log.Println("Worker stopped")
+}
+
+// @@@SNIPEND

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,16 @@ go 1.25.4
 
 replace github.com/cactus/go-statsd-client => github.com/cactus/go-statsd-client/v5 v5.0.0
 
+// TEMPORARY: go.temporal.io/sdk/contrib/gcp/cloudrun and its shared
+// go.temporal.io/sdk/contrib/opentelemetry/otlpworker dependency are not yet
+// published. These local replaces let the sample build against the in-repo
+// modules. Remove them before publishing the sample PR (and after the modules
+// are released).
+replace (
+	go.temporal.io/sdk/contrib/gcp/cloudrun => ../sdk-go/contrib/gcp/cloudrun
+	go.temporal.io/sdk/contrib/opentelemetry/otlpworker => ../sdk-go/contrib/opentelemetry/otlpworker
+)
+
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
@@ -33,7 +43,8 @@ require (
 	go.temporal.io/sdk/contrib/aws/s3driver/awssdkv2 v0.2.0
 	go.temporal.io/sdk/contrib/datadog v0.5.0
 	go.temporal.io/sdk/contrib/envconfig v1.0.1
-	go.temporal.io/sdk/contrib/opentelemetry v0.7.0
+	go.temporal.io/sdk/contrib/gcp/cloudrun v0.1.0
+	go.temporal.io/sdk/contrib/opentelemetry v0.8.1
 	go.temporal.io/sdk/contrib/opentracing v0.3.0
 	go.temporal.io/sdk/contrib/tally v0.2.0
 	go.temporal.io/sdk/contrib/workflowstreams v0.1.1
@@ -47,6 +58,8 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+require go.temporal.io/sdk/contrib/opentelemetry/otlpworker v0.1.0 // indirect
 
 require (
 	cloud.google.com/go v0.123.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/temporalio/samples-go
 
-go 1.25.4
+go 1.26.0
 
 replace github.com/cactus/go-statsd-client => github.com/cactus/go-statsd-client/v5 v5.0.0
 

--- a/go.sum
+++ b/go.sum
@@ -522,8 +522,8 @@ go.temporal.io/sdk/contrib/envconfig v1.0.1 h1:HZCcS6vNPJiUxJrkc5Wdeen+056LWmYe2
 go.temporal.io/sdk/contrib/envconfig v1.0.1/go.mod h1:aCFIuADlPNv6bYK5Zp4YfB/PnGfpiSPVzJfvaSTCYtw=
 go.temporal.io/sdk/contrib/googleadk v0.2.0 h1:cAcwnRb86qf6pdBMYEWmcfP8d5aPSjiFWJw5ctGUZYI=
 go.temporal.io/sdk/contrib/googleadk v0.2.0/go.mod h1:blDAd6sIyExkjtPP1Q52mUXHNJCfkRyWaNPtr51977g=
-go.temporal.io/sdk/contrib/opentelemetry v0.7.0 h1:GSna1HP+1ibNXZ9xlVdQU2zFVqdt5VcdF0dzpeaYccQ=
-go.temporal.io/sdk/contrib/opentelemetry v0.7.0/go.mod h1:oQJC6UIl3FbSYh4f2MlUAIYSE6FPw02X1Tw8/bOvfxg=
+go.temporal.io/sdk/contrib/opentelemetry v0.8.1 h1:wmQnxBWUsQQN6QihaEuUmsn8ZK6d+2G9oQF5bN4ObiY=
+go.temporal.io/sdk/contrib/opentelemetry v0.8.1/go.mod h1:NnJgL/EwJIaWZVx4Vmb/qMh18a0fTu00VG/ojQ7tHPY=
 go.temporal.io/sdk/contrib/opentracing v0.3.0 h1:IKJgyvZiaOSFl0YHSxJpwXwQa08W3KaZCJkbx05rX7Q=
 go.temporal.io/sdk/contrib/opentracing v0.3.0/go.mod h1:hMs5MBzEluvFhExS8n8I2gNrk3rTrg07uHYi7W2TDbw=
 go.temporal.io/sdk/contrib/tally v0.2.0 h1:XnTJIQcjOv+WuCJ1u8Ve2nq+s2H4i/fys34MnWDRrOo=


### PR DESCRIPTION
## Summary

Adds `cloud-run-worker/`: a long-running Temporal worker for Google Cloud Run worker pools that uses the new `contrib/gcp/cloudrun` OpenTelemetry plugin to export Core metrics and traces over OTLP/gRPC to a local OpenTelemetry Collector sidecar. Includes the worker + starter, a greeting workflow/activity, an OTel collector config (metrics → `googlemanagedprometheus` with no batch processor; traces → `googlecloud`), a Cloud Run worker-pool manifest, a Dockerfile, and a README.

## ⚠️ Draft — blocked on SDK release

Depends on the unreleased `go.temporal.io/sdk/contrib/gcp/cloudrun` (and its `otlpworker` dependency) from **temporalio/sdk-go#2588**. To keep it buildable locally, `go.mod` temporarily uses two local `replace` directives pointing at a sibling `sdk-go` checkout. Before marking ready:

- [ ] Release `contrib/opentelemetry/otlpworker`, then `contrib/gcp/cloudrun`
- [ ] Remove the temporary `replace` directives from `go.mod` and pin the released versions
- [ ] Confirm the container build (context = samples repo) resolves the published modules

## Related

SDK PR: temporalio/sdk-go#2588. Cross-SDK Cloud Run OTel preview (Go/Java/Python/.NET).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
